### PR TITLE
Fix IRenderable deprecated message

### DIFF
--- a/ScriptBinder/IRenderable.h
+++ b/ScriptBinder/IRenderable.h
@@ -3,10 +3,10 @@
 #define interface struct
 #endif
 
-//TODO : 컬링 기본 객체로 변경할 예정
-interface 
-[[deprecated("Will be change IRenderable interface soon, Please! Don't inheritance this interface")]] 
-IRenderable
+[[deprecated("IRenderable interface will change soon. Please do not inherit from this interface.")]] 
+	[[deprecated("IRenderable interface will change soon. Please do not inherit from this interface.")]]
+	[[deprecated("IRenderable interface will change soon. Please do not inherit from this interface.")]]
+};
 {
 	[[deprecated("Will be change IRenderable interface soon, Please! Don't inheritance this interface")]]
 	virtual bool IsEnabled() const = 0;


### PR DESCRIPTION
## Summary
- update the `[[deprecated]]` messages in `IRenderable.h`
- ensure the header ends with a newline

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847621149c4832dad91567a715bf555