### PR TITLE
Add null return path in Animator

### DIFF
--- a/ScriptBinder/Animator.cpp
+++ b/ScriptBinder/Animator.cpp
@@ -83,11 +83,13 @@ void Animator::CreateController_UI()
 
 AnimationController* Animator::GetController(std::string name)
 {
-	for (auto& Controller : m_animationControllers)
-	{
-		if (Controller->name == name)
-			return Controller;
-	}
+        for (auto& Controller : m_animationControllers)
+        {
+                if (Controller->name == name)
+                        return Controller;
+        }
+        // Return nullptr when no controller with the specified name exists
+        return nullptr;
 }
 
 


### PR DESCRIPTION
## Summary
- ensure `Animator::GetController` returns `nullptr` when the named controller is missing
- document the missing controller case

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6847620e7900832dbfcf8a78517f9c9b