### PR TITLE
Implement basic prefab functionality

### DIFF
--- a/ScriptBinder/Prefab.cpp
+++ b/ScriptBinder/Prefab.cpp
@@ -1,0 +1,66 @@
+#include "Prefab.h"
+
+Prefab::Prefab(const std::string_view& name, const GameObject* source)
+    : Object(name)
+{
+    m_typeID = TypeTrait::GUIDCreator::GetTypeID<Prefab>();
+    if (source)
+    {
+        const Meta::Type* type = Meta::MetaDataRegistry->Find(source->GetTypeID());
+        if (type)
+        {
+            GameObject* nonConst = const_cast<GameObject*>(source);
+            m_prefabData = Meta::Serialize(nonConst, *type);
+        }
+    }
+}
+
+Prefab* Prefab::CreateFromGameObject(const GameObject* source, const std::string_view& name)
+{
+    if (!source)
+        return nullptr;
+
+    std::string prefabName = name.empty() ? source->GetHashedName().ToString() + "_Prefab" : std::string(name);
+    return new Prefab(prefabName, source);
+}
+
+GameObject* Prefab::Instantiate(const std::string_view& newName) const
+{
+    if (!m_prefabData)
+        return nullptr;
+
+    Scene* scene = SceneManagers->GetActiveScene();
+    if (!scene)
+        return nullptr;
+
+    GameObjectType type = m_prefabData["m_gameObjectType"].as<GameObjectType>();
+    GameObject::Index parent = m_prefabData["m_parentIndex"].as<GameObject::Index>();
+
+    auto objPtr = scene->LoadGameObject(make_guid(), newName.empty() ? m_prefabData["m_name"].as<std::string>() : std::string(newName), type, parent);
+    GameObject* obj = objPtr.get();
+
+    const Meta::Type* meta = Meta::MetaDataRegistry->Find(TypeTrait::GUIDCreator::GetTypeID<GameObject>());
+    if (meta && obj)
+    {
+        Meta::Deserialize(obj, m_prefabData);
+    }
+
+    if (m_prefabData["m_components"])
+    {
+        for (const auto& componentNode : m_prefabData["m_components"])
+        {
+            try
+            {
+                ComponentFactorys->LoadComponent(obj, componentNode);
+            }
+            catch (const std::exception& e)
+            {
+                Debug->LogError(e.what());
+                continue;
+            }
+        }
+    }
+
+    return obj;
+}
+

--- a/ScriptBinder/Prefab.h
+++ b/ScriptBinder/Prefab.h
@@ -1,0 +1,23 @@
+#pragma once
+#include "Object.h"
+#include "GameObject.h"
+#include "ReflectionYml.h"
+#include "SceneManager.h"
+#include "ComponentFactory.h"
+
+class Prefab : public Object
+{
+public:
+    [[Serializable(Inheritance:Object)]]
+    Prefab() = default;
+    Prefab(const std::string_view& name, const GameObject* source);
+    ~Prefab() override = default;
+
+    static Prefab* CreateFromGameObject(const GameObject* source, const std::string_view& name = "");
+
+    GameObject* Instantiate(const std::string_view& newName = "") const;
+
+private:
+    MetaYml::Node m_prefabData{};
+};
+

--- a/ScriptBinder/PrefabUtility.cpp
+++ b/ScriptBinder/PrefabUtility.cpp
@@ -1,0 +1,14 @@
+#include "PrefabUtility.h"
+
+Prefab* PrefabUtility::CreatePrefab(const GameObject* source, const std::string_view& name)
+{
+    return Prefab::CreateFromGameObject(source, name);
+}
+
+GameObject* PrefabUtility::InstantiatePrefab(const Prefab* prefab, const std::string_view& name)
+{
+    if (!prefab)
+        return nullptr;
+    return prefab->Instantiate(name);
+}
+

--- a/ScriptBinder/PrefabUtility.h
+++ b/ScriptBinder/PrefabUtility.h
@@ -1,18 +1,21 @@
 #pragma once
 #include "Core.Minimal.h"
+#include "Prefab.h"
 
-class GameObject;
 class PrefabUtility : public Singleton<PrefabUtility>
 {
 private:
-	friend class Singleton;
-	PrefabUtility() = default;
-	~PrefabUtility() = default;
+    friend class Singleton;
+    PrefabUtility() = default;
+    ~PrefabUtility() = default;
 
 public:
-	Core::Delegate<void, GameObject&> prefabInstanceUpdated;
-	Core::Delegate<void, GameObject&> prefabInstanceApplied;
-	Core::Delegate<void, GameObject&> prefabInstanceReverted;
-	Core::Delegate<void, GameObject&> prefabInstanceUnpacked;
+    Core::Delegate<void, GameObject&> prefabInstanceUpdated;
+    Core::Delegate<void, GameObject&> prefabInstanceApplied;
+    Core::Delegate<void, GameObject&> prefabInstanceReverted;
+    Core::Delegate<void, GameObject&> prefabInstanceUnpacked;
 
+    Prefab* CreatePrefab(const GameObject* source, const std::string_view& name = "");
+    GameObject* InstantiatePrefab(const Prefab* prefab, const std::string_view& name = "");
 };
+


### PR DESCRIPTION
## Summary
- add new `Prefab` class that serializes a `GameObject`
- extend `PrefabUtility` to create and instantiate prefabs

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686331af6d3c832db20d439e35350a1d