### PR TITLE
Refactor ModelLoader asset serialization

### DIFF
--- a/RenderEngine/ModelLoader.cpp
+++ b/RenderEngine/ModelLoader.cpp
@@ -321,125 +321,195 @@ Material* ModelLoader::GenerateMaterial(int index)
 
 void ModelLoader::ParseModel()
 {
-	std::fstream file;
-	file::path filepath = PathFinder::Relative("Models\\").string() + m_model->name + ".asset";
-	file.open(filepath, std::ios::out | std::ios::binary);
-	if (file.is_open())
-	{
-		uint32 size = m_model->m_nodes.size();
-		file.write(reinterpret_cast<char*>(&size), sizeof(uint32));
-		ParseNodes(file);
-		ParseMeshes(file);
-		ParseMaterials(file);
-		file.close();
-	}
+    file::path filepath = PathFinder::Relative("Models\\") / (m_model->name + ".asset");
+    std::ofstream file(filepath, std::ios::binary);
+    if (!file)
+        return;
+
+    uint32_t nodeCount   = static_cast<uint32_t>(m_model->m_nodes.size());
+    uint32_t meshCount   = static_cast<uint32_t>(m_model->m_Meshes.size());
+    uint32_t materialCnt = static_cast<uint32_t>(m_model->m_Materials.size());
+
+    file.write(reinterpret_cast<char*>(&nodeCount), sizeof(nodeCount));
+    file.write(reinterpret_cast<char*>(&meshCount), sizeof(meshCount));
+    file.write(reinterpret_cast<char*>(&materialCnt), sizeof(materialCnt));
+
+    ParseNodes(file);
+    ParseMeshes(file);
+    ParseMaterials(file);
 }
 
-void ModelLoader::ParseNodes(std::fstream& outfile)
+void ModelLoader::ParseNodes(std::ofstream& outfile)
 {
-	for (uint32 i = 0; i < m_model->m_nodes.size(); i++)
-	{
-		ModelNode* node = m_model->m_nodes[i];
-		ParseNode(outfile, node);
-	}
+    for (const ModelNode* node : m_model->m_nodes)
+    {
+        ParseNode(outfile, node);
+    }
 }
 
-void ModelLoader::ParseNode(std::fstream& outfile, ModelNode* node)
+void ModelLoader::ParseNode(std::ofstream& outfile, const ModelNode* node)
 {
-	size_t strSize = node->m_name.size();
-	outfile.write(reinterpret_cast<char*>(&strSize), sizeof(size_t));
-	outfile.write(reinterpret_cast<char*>(node->m_name.data()), strSize);
-	outfile.write(reinterpret_cast<char*>(&node->m_index), sizeof(uint32));
-	outfile.write(reinterpret_cast<char*>(&node->m_parentIndex), sizeof(uint32));
-	outfile.write(reinterpret_cast<char*>(&node->m_numMeshes), sizeof(uint32));
-	outfile.write(reinterpret_cast<char*>(&node->m_numChildren), sizeof(uint32));
-	outfile.write(reinterpret_cast<char*>(&node->m_transform), sizeof(Mathf::Matrix));
-	outfile.write(reinterpret_cast<char*>(node->m_meshes.data()), sizeof(uint32) * node->m_meshes.size());
-	outfile.write(reinterpret_cast<char*>(node->m_childrenIndex.data()), sizeof(uint32) * node->m_childrenIndex.size());
+    uint32_t nameSize = static_cast<uint32_t>(node->m_name.size());
+    outfile.write(reinterpret_cast<char*>(&nameSize), sizeof(nameSize));
+    outfile.write(node->m_name.data(), nameSize);
+
+    outfile.write(reinterpret_cast<const char*>(&node->m_index), sizeof(node->m_index));
+    outfile.write(reinterpret_cast<const char*>(&node->m_parentIndex), sizeof(node->m_parentIndex));
+    outfile.write(reinterpret_cast<const char*>(&node->m_numMeshes), sizeof(node->m_numMeshes));
+    outfile.write(reinterpret_cast<const char*>(&node->m_numChildren), sizeof(node->m_numChildren));
+    outfile.write(reinterpret_cast<const char*>(&node->m_transform), sizeof(Mathf::Matrix));
+
+    if (!node->m_meshes.empty())
+        outfile.write(reinterpret_cast<const char*>(node->m_meshes.data()), node->m_meshes.size() * sizeof(uint32_t));
+    if (!node->m_childrenIndex.empty())
+        outfile.write(reinterpret_cast<const char*>(node->m_childrenIndex.data()), node->m_childrenIndex.size() * sizeof(uint32_t));
 }
 
-void ModelLoader::ParseMeshes(std::fstream& outfile)
+void ModelLoader::ParseMeshes(std::ofstream& outfile)
 {
-	for (uint32 i = 0; i < m_model->m_Meshes.size(); i++)
-	{
-		Mesh* mesh = m_model->m_Meshes[i];
-		outfile.write(reinterpret_cast<char*>(mesh->m_name.data()), sizeof(mesh->m_name.size()));
-		outfile.write(reinterpret_cast<char*>(mesh->m_vertices.data()), mesh->m_vertices.size() * sizeof(Vertex));
-		outfile.write(reinterpret_cast<char*>(mesh->m_indices.data()), mesh->m_indices.size() * sizeof(uint32));
-		//outfile.write(reinterpret_cast<char*>(&mesh->m_transform), sizeof(Mathf::Matrix));
-		outfile.write(reinterpret_cast<char*>(&mesh->m_boundingBox), sizeof(DirectX::BoundingBox));
-		outfile.write(reinterpret_cast<char*>(&mesh->m_boundingSphere), sizeof(DirectX::BoundingSphere));
-	}
+    for (const Mesh* mesh : m_model->m_Meshes)
+    {
+        uint32_t nameSize = static_cast<uint32_t>(mesh->m_name.size());
+        outfile.write(reinterpret_cast<char*>(&nameSize), sizeof(nameSize));
+        outfile.write(mesh->m_name.data(), nameSize);
+        outfile.write(reinterpret_cast<const char*>(&mesh->m_materialIndex), sizeof(mesh->m_materialIndex));
+
+        uint32_t vertexCount = static_cast<uint32_t>(mesh->m_vertices.size());
+        outfile.write(reinterpret_cast<char*>(&vertexCount), sizeof(vertexCount));
+        if (vertexCount)
+            outfile.write(reinterpret_cast<const char*>(mesh->m_vertices.data()), vertexCount * sizeof(Vertex));
+
+        uint32_t indexCount = static_cast<uint32_t>(mesh->m_indices.size());
+        outfile.write(reinterpret_cast<char*>(&indexCount), sizeof(indexCount));
+        if (indexCount)
+            outfile.write(reinterpret_cast<const char*>(mesh->m_indices.data()), indexCount * sizeof(uint32_t));
+
+        outfile.write(reinterpret_cast<const char*>(&mesh->m_boundingBox), sizeof(DirectX::BoundingBox));
+        outfile.write(reinterpret_cast<const char*>(&mesh->m_boundingSphere), sizeof(DirectX::BoundingSphere));
+    }
 }
 
-void ModelLoader::ParseMaterials(std::fstream& outfile)
+void ModelLoader::ParseMaterials(std::ofstream& outfile)
 {
+    for (const Material* mat : m_model->m_Materials)
+    {
+        uint32_t nameSize = static_cast<uint32_t>(mat->m_name.size());
+        outfile.write(reinterpret_cast<char*>(&nameSize), sizeof(nameSize));
+        outfile.write(mat->m_name.data(), nameSize);
+        outfile.write(reinterpret_cast<const char*>(&mat->m_materialInfo), sizeof(MaterialInfomation));
+        outfile.write(reinterpret_cast<const char*>(&mat->m_renderingMode), sizeof(mat->m_renderingMode));
+        outfile.write(reinterpret_cast<const char*>(&mat->m_fileGuid), sizeof(FileGuid));
+    }
 }
 
 void ModelLoader::LoadModelFromAsset()
 {
-	std::fstream file;
-	file::path filepath = PathFinder::Relative("Models\\").string() + m_model->name + ".asset";
-	file.open(filepath, std::ios::in | std::ios::binary);
-	if (file.is_open())
-	{
-        uint32 size{};
-		file.read(reinterpret_cast<char*>(&size), sizeof(uint32));
-		m_model->m_nodes.resize(size);
-		LoadNodes(file, size);
-		LoadMesh(file);
-		LoadMaterial(file);
-		file.close();
-	}
+    file::path filepath = PathFinder::Relative("Models\\") / (m_model->name + ".asset");
+    std::ifstream file(filepath, std::ios::binary);
+    if (!file)
+        return;
+
+    uint32_t nodeCount{};
+    uint32_t meshCount{};
+    uint32_t materialCount{};
+
+    file.read(reinterpret_cast<char*>(&nodeCount), sizeof(nodeCount));
+    file.read(reinterpret_cast<char*>(&meshCount), sizeof(meshCount));
+    file.read(reinterpret_cast<char*>(&materialCount), sizeof(materialCount));
+
+    LoadNodes(file, nodeCount);
+    LoadMesh(file, meshCount);
+    LoadMaterial(file, materialCount);
 }
 
-void ModelLoader::LoadNodes(std::fstream& infile, uint32 size)
+void ModelLoader::LoadNodes(std::ifstream& infile, uint32_t size)
 {
-	for (uint32 i = 0; i < size; i++)
-	{
-		LoadNode(infile, m_model->m_nodes[i]);
-	}
+    m_model->m_nodes.reserve(size);
+    for (uint32_t i = 0; i < size; ++i)
+    {
+        ModelNode* node{};
+        LoadNode(infile, node);
+        m_model->m_nodes.push_back(node);
+    }
 }
 
-void ModelLoader::LoadNode(std::fstream& infile, ModelNode* node)
+void ModelLoader::LoadNode(std::ifstream& infile, ModelNode*& node)
 {
-    size_t size{};
-	std::string name;
-	infile.read(reinterpret_cast<char*>(&size), sizeof(size_t));
-	infile.read(reinterpret_cast<char*>(name.data()), size);
-	node = new ModelNode(name);
+    uint32_t nameSize{};
+    infile.read(reinterpret_cast<char*>(&nameSize), sizeof(nameSize));
+    std::string name;
+    name.resize(nameSize);
+    infile.read(name.data(), nameSize);
 
-	infile.read(reinterpret_cast<char*>(&node->m_index), sizeof(uint32));
-	infile.read(reinterpret_cast<char*>(&node->m_parentIndex), sizeof(uint32));
-	infile.read(reinterpret_cast<char*>(&node->m_numMeshes), sizeof(uint32));
-	infile.read(reinterpret_cast<char*>(&node->m_numChildren), sizeof(uint32));
-	infile.read(reinterpret_cast<char*>(&node->m_transform), sizeof(Mathf::Matrix));
-	infile.read(reinterpret_cast<char*>(node->m_meshes.data()), sizeof(uint32) * node->m_numMeshes);
-	infile.read(reinterpret_cast<char*>(node->m_childrenIndex.data()), sizeof(uint32) * node->m_numChildren);
+    node = AllocateResource<ModelNode>(name);
+
+    infile.read(reinterpret_cast<char*>(&node->m_index), sizeof(node->m_index));
+    infile.read(reinterpret_cast<char*>(&node->m_parentIndex), sizeof(node->m_parentIndex));
+    infile.read(reinterpret_cast<char*>(&node->m_numMeshes), sizeof(node->m_numMeshes));
+    infile.read(reinterpret_cast<char*>(&node->m_numChildren), sizeof(node->m_numChildren));
+    infile.read(reinterpret_cast<char*>(&node->m_transform), sizeof(Mathf::Matrix));
+
+    node->m_meshes.resize(node->m_numMeshes);
+    node->m_childrenIndex.resize(node->m_numChildren);
+    if (node->m_numMeshes)
+        infile.read(reinterpret_cast<char*>(node->m_meshes.data()), node->m_numMeshes * sizeof(uint32_t));
+    if (node->m_numChildren)
+        infile.read(reinterpret_cast<char*>(node->m_childrenIndex.data()), node->m_numChildren * sizeof(uint32_t));
 }
 
-void ModelLoader::LoadMesh(std::fstream& infile)
+void ModelLoader::LoadMesh(std::ifstream& infile, uint32_t size)
 {
-	for (uint32 i = 0; i < m_model->m_nodes.size(); i++)
-	{
-		ModelNode* node = m_model->m_nodes[i];
-		for (uint32 j = 0; j < node->m_numMeshes; j++)
-		{
-			Mesh* mesh = new Mesh();
-			infile.read(reinterpret_cast<char*>(mesh->m_name.data()), sizeof(mesh->m_name.size()));
-			infile.read(reinterpret_cast<char*>(mesh->m_vertices.data()), mesh->m_vertices.size() * sizeof(Vertex));
-			infile.read(reinterpret_cast<char*>(mesh->m_indices.data()), mesh->m_indices.size() * sizeof(uint32));
-			//infile.read(reinterpret_cast<char*>(&mesh->m_transform), sizeof(Mathf::Matrix));
-			infile.read(reinterpret_cast<char*>(&mesh->m_boundingBox), sizeof(DirectX::BoundingBox));
-			infile.read(reinterpret_cast<char*>(&mesh->m_boundingSphere), sizeof(DirectX::BoundingSphere));
-			m_model->m_Meshes.push_back(mesh);
-			//m_model->m_Materials.push_back(new Material());
-		}
-	}
+    m_model->m_Meshes.reserve(size);
+    for (uint32_t i = 0; i < size; ++i)
+    {
+        uint32_t nameSize{};
+        infile.read(reinterpret_cast<char*>(&nameSize), sizeof(nameSize));
+        std::string name;
+        name.resize(nameSize);
+        infile.read(name.data(), nameSize);
+
+        auto* mesh = AllocateResource<Mesh>();
+        mesh->m_name = name;
+        infile.read(reinterpret_cast<char*>(&mesh->m_materialIndex), sizeof(mesh->m_materialIndex));
+
+        uint32_t vertexCount{};
+        infile.read(reinterpret_cast<char*>(&vertexCount), sizeof(vertexCount));
+        mesh->m_vertices.resize(vertexCount);
+        if (vertexCount)
+            infile.read(reinterpret_cast<char*>(mesh->m_vertices.data()), vertexCount * sizeof(Vertex));
+
+        uint32_t indexCount{};
+        infile.read(reinterpret_cast<char*>(&indexCount), sizeof(indexCount));
+        mesh->m_indices.resize(indexCount);
+        if (indexCount)
+            infile.read(reinterpret_cast<char*>(mesh->m_indices.data()), indexCount * sizeof(uint32_t));
+
+        infile.read(reinterpret_cast<char*>(&mesh->m_boundingBox), sizeof(DirectX::BoundingBox));
+        infile.read(reinterpret_cast<char*>(&mesh->m_boundingSphere), sizeof(DirectX::BoundingSphere));
+
+        m_model->m_Meshes.push_back(mesh);
+    }
 }
 
-void ModelLoader::LoadMaterial(std::fstream& infile)
+void ModelLoader::LoadMaterial(std::ifstream& infile, uint32_t size)
 {
+    m_model->m_Materials.reserve(size);
+    for (uint32_t i = 0; i < size; ++i)
+    {
+        uint32_t nameSize{};
+        infile.read(reinterpret_cast<char*>(&nameSize), sizeof(nameSize));
+        std::string name;
+        name.resize(nameSize);
+        infile.read(name.data(), nameSize);
+
+        Material* mat = AllocateResource<Material>();
+        mat->m_name = name;
+        infile.read(reinterpret_cast<char*>(&mat->m_materialInfo), sizeof(MaterialInfomation));
+        infile.read(reinterpret_cast<char*>(&mat->m_renderingMode), sizeof(mat->m_renderingMode));
+        infile.read(reinterpret_cast<char*>(&mat->m_fileGuid), sizeof(FileGuid));
+
+        m_model->m_Materials.push_back(mat);
+    }
 }
 
 void ModelLoader::ProcessBones(aiMesh* mesh, std::vector<Vertex>& vertices)

--- a/RenderEngine/ModelLoader.h
+++ b/RenderEngine/ModelLoader.h
@@ -37,16 +37,16 @@ private:
 
 	//Save To InHouse Format
 	void ParseModel();
-	void ParseNodes(std::fstream& outfile);
-	void ParseNode(std::fstream& outfile, ModelNode* node);
-	void ParseMeshes(std::fstream& outfile);
-	void ParseMaterials(std::fstream& outfile);
+	void ParseNodes(std::ofstream& outfile);
+	void ParseNode(std::ofstream& outfile, const ModelNode* node);
+	void ParseMeshes(std::ofstream& outfile);
+	void ParseMaterials(std::ofstream& outfile);
 
 	void LoadModelFromAsset();
-	void LoadNodes(std::fstream& infile, uint32 size);
-	void LoadNode(std::fstream& infile, ModelNode* node);
-	void LoadMesh(std::fstream& infile);
-	void LoadMaterial(std::fstream& infile);
+	void LoadNodes(std::ifstream& infile, uint32_t size);
+	void LoadNode(std::ifstream& infile, ModelNode*& node);
+	void LoadMesh(std::ifstream& infile, uint32_t size);
+	void LoadMaterial(std::ifstream& infile, uint32_t size);
 
 	Model* LoadModel(bool isCreateMeshCollider = false);
 	void GenerateSceneObjectHierarchy(ModelNode* node, bool isRoot, int parentIndex);
@@ -55,7 +55,7 @@ private:
 	GameObject* GenerateSceneObjectHierarchyObj(ModelNode* node, bool isRoot, int parentIndex);
 	GameObject* GenerateSkeletonToSceneObjectHierarchyObj(ModelNode* node, Bone* bone, bool isRoot, int parentIndex);
 	Texture* GenerateTexture(aiMaterial* material, aiTextureType type, uint32 index = 0);
-	//¿©±â Á» Á¤¸®°¡ ÇÊ¿äÇÒ µí
+	//Â¿Â©Â±Ã¢ ÃÂ» ÃÂ¤Â¸Â®Â°Â¡ Ã‡ÃŠÂ¿Ã¤Ã‡Ã’ ÂµÃ­
 	//std::shared_ptr<Assimp::Importer> m_importer{};
 	const aiScene* m_AIScene;
 	LoadType m_loadType{ LoadType::UNKNOWN };


### PR DESCRIPTION
## Summary
- rewrite ModelLoader parsing helpers to use `std::ifstream`/`std::ofstream`
- write node, mesh and material data in binary using counts
- update loading code to match new asset layout

## Testing
- `clang++ -std=c++20 -fsyntax-only RenderEngine/ModelLoader.cpp -I Utility_Framework -I RenderEngine` *(fails: 'dxgi1_4.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68637e252460832db60378c863bcf8c1