### PR TITLE
Add texture names to .asset and apply textures on load

### DIFF
--- a/RenderEngine/ModelLoader.h
+++ b/RenderEngine/ModelLoader.h
@@ -54,7 +54,8 @@ private:
 
 	GameObject* GenerateSceneObjectHierarchyObj(ModelNode* node, bool isRoot, int parentIndex);
 	GameObject* GenerateSkeletonToSceneObjectHierarchyObj(ModelNode* node, Bone* bone, bool isRoot, int parentIndex);
-	Texture* GenerateTexture(aiMaterial* material, aiTextureType type, uint32 index = 0);
+        Texture* GenerateTexture(aiMaterial* material, aiTextureType type, uint32 index = 0);
+        Texture* GenerateTexture(const std::string& textureName);
 	//¿©±â Á» Á¤¸®°¡ ÇÊ¿äÇÒ µí
 	//std::shared_ptr<Assimp::Importer> m_importer{};
 	const aiScene* m_AIScene;


### PR DESCRIPTION
## Summary
- store material texture names when saving `.asset` files
- read texture names back and load textures automatically
- expose a helper overload to load textures from a name

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_686461416d2c832dae1397dfa5cd0d34