### PR TITLE
Update texture generation API

### DIFF
--- a/RenderEngine/ModelLoader.cpp
+++ b/RenderEngine/ModelLoader.cpp
@@ -1112,19 +1112,17 @@ Texture* ModelLoader::GenerateTexture(aiMaterial* material, aiTextureType type, 
     return texture;
 }
 
-Texture* ModelLoader::GenerateTexture(const std::string& textureName)
+Texture* ModelLoader::GenerateTexture(std::string_view textureName)
 {
     if (textureName.empty())
-            return nullptr;
+        return nullptr;
 
-    std::wstring stemp = std::wstring(textureName.begin(), textureName.end());
-    file::path _path = stemp.c_str();
-
-    Texture* texture = DataSystems->LoadMaterialTexture(_path.string());
+    file::path path(textureName);
+    Texture* texture = DataSystems->LoadMaterialTexture(path.string());
     if (texture)
     {
-            texture->m_name = textureName;
-            m_model->m_Textures.push_back(texture);
+        texture->m_name = std::string(textureName);
+        m_model->m_Textures.push_back(texture);
     }
     return texture;
 }

--- a/RenderEngine/ModelLoader.h
+++ b/RenderEngine/ModelLoader.h
@@ -57,7 +57,7 @@ private:
 	GameObject* GenerateSceneObjectHierarchyObj(ModelNode* node, bool isRoot, int parentIndex);
 	GameObject* GenerateSkeletonToSceneObjectHierarchyObj(ModelNode* node, Bone* bone, bool isRoot, int parentIndex);
     Texture* GenerateTexture(aiMaterial* material, aiTextureType type, uint32 index = 0);
-    Texture* GenerateTexture(const std::string& textureName);
+    Texture* GenerateTexture(std::string_view textureName);
 
 	const aiScene* m_AIScene;
 	LoadType m_loadType{ LoadType::UNKNOWN };


### PR DESCRIPTION
## Summary
- adjust `GenerateTexture` to accept `std::string_view`
- simplify texture loading path usage

## Testing
- `g++ -std=c++20 -c RenderEngine/ModelLoader.cpp -I./ -IUtility_Framework -IRenderEngine` *(fails: `dxgi1_4.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864bcf3ec24832db09f98c7665d2808