### PR TITLE
Add game object capacity API

### DIFF
--- a/RenderEngine/Model.cpp
+++ b/RenderEngine/Model.cpp
@@ -199,8 +199,9 @@ Model* Model::LoadModelToScene(Model* model, Scene& Scene)
         return nullptr;
     }
 
-	ModelLoader loader = ModelLoader(model, &Scene);
-	file::path path_ = model->path;
+        ModelLoader loader = ModelLoader(model, &Scene);
+        loader.ReserveGameObjectCapacity(model->m_nodes.size());
+        file::path path_ = model->path;
 	loader.GenerateSceneObjectHierarchy(model->m_nodes[0], true, 0);
 	if (model->m_hasBones)
 	{
@@ -219,8 +220,9 @@ GameObject* Model::LoadModelToSceneObj(Model* model, Scene& Scene)
 		return nullptr;
 	}
 
-	ModelLoader loader = ModelLoader(model, &Scene);
-	file::path path_ = model->path;
+        ModelLoader loader = ModelLoader(model, &Scene);
+        loader.ReserveGameObjectCapacity(model->m_nodes.size());
+        file::path path_ = model->path;
 
 	auto rootObj = loader.GenerateSceneObjectHierarchyObj(model->m_nodes[0], true, 0);
 	if (model->m_hasBones)

--- a/RenderEngine/ModelLoader.cpp
+++ b/RenderEngine/ModelLoader.cpp
@@ -32,8 +32,8 @@ ModelLoader::ModelLoader(const std::string_view& fileName)
 }
 
 ModelLoader::ModelLoader(const aiScene* assimpScene, const std::string_view& fileName) :
-	m_AIScene(assimpScene),
-	m_skeletonLoader(assimpScene)
+        m_AIScene(assimpScene),
+        m_skeletonLoader(assimpScene)
 {
 	file::path filepath(fileName);
 	m_directory = filepath.parent_path().string() + "\\";
@@ -56,13 +56,18 @@ ModelLoader::ModelLoader(const aiScene* assimpScene, const std::string_view& fil
 	}
 	m_model = AllocateResource<Model>();
 	m_model->name = filepath.stem().string();
-	if(m_AIScene)
-	{
-		if (0 < m_AIScene->mNumAnimations)
-		{
-			m_model->m_animator = new Animator();
-		}
-	}
+        if(m_AIScene)
+        {
+                if (0 < m_AIScene->mNumAnimations)
+                {
+                        m_model->m_animator = new Animator();
+                }
+        }
+}
+
+void ModelLoader::ReserveGameObjectCapacity(size_t capacity)
+{
+        m_gameObjects.reserve(capacity);
 }
 
 void ModelLoader::ProcessNodes()

--- a/RenderEngine/ModelLoader.h
+++ b/RenderEngine/ModelLoader.h
@@ -10,17 +10,20 @@
 
 class ModelLoader
 {
-	enum class LoadType
-	{
-		UNKNOWN,
-		OBJ,
-		GLTF,
-		FBX,
-		ASSET
-	};
+        enum class LoadType
+        {
+                UNKNOWN,
+                OBJ,
+                GLTF,
+                FBX,
+                ASSET
+        };
+
+public:
+        void ReserveGameObjectCapacity(size_t capacity);
 
 private:
-	friend class Model;
+        friend class Model;
 	ModelLoader();
 	~ModelLoader();
 	ModelLoader(Model* model, Scene* scene);


### PR DESCRIPTION
## Summary
- add public `ReserveGameObjectCapacity` to `ModelLoader`
- preallocate loader vector before creating scene objects

## Testing
- `clang++ -std=c++20 RenderEngine/ModelLoader.cpp -I. -I./RenderEngine -I./Utility_Framework -fsyntax-only` *(fails: 'dxgi1_4.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864bcef124c832db2eb7cdec7a1c054