### PR TITLE
Add render pass settings serialization

### DIFF
--- a/EngineEntry/EngineSetting.h
+++ b/EngineEntry/EngineSetting.h
@@ -7,6 +7,7 @@
 #include "Core.Barrier.h"
 
 #include <yaml-cpp/yaml.h>
+#include "RenderPassSettings.h"
 namespace MetaYml = YAML;
 
 enum class MSVCVersion
@@ -38,7 +39,7 @@ public:
 			return false;
 		}
 
-		// �ٹٲ� ����
+		// ÁÙ¹Ù²Þ Á¦°Å
 		output.erase(std::remove(output.begin(), output.end(), '\r'), output.end());
 		output.erase(std::remove(output.begin(), output.end(), '\n'), output.end());
 
@@ -120,7 +121,10 @@ public:
 	Mathf::Vector2 GetWindowSize() const
 	{
 		return m_lastWindowSize;
-	}
+        }
+
+        RenderPassSettings& GetRenderPassSettings() { return m_renderPassSettings; }
+        const RenderPassSettings& GetRenderPassSettings() const { return m_renderPassSettings; }
 
 	void SetImGuiInitialized(bool isInitialized)
 	{
@@ -143,6 +147,7 @@ public:
 		rootNode["lastWindowSize"]["x"] = m_lastWindowSize.x;
 		rootNode["lastWindowSize"]["y"] = m_lastWindowSize.y;
 		rootNode["msvcVersion"] = static_cast<int>(m_msvcVersion);
+        rootNode["renderPassSettings"] = Meta::Serialize(&m_renderPassSettings);
 
 		settingsFile << rootNode;
 
@@ -171,6 +176,8 @@ public:
 			rootNode["lastWindowSize"]["y"].as<float>() 
 		};
 		m_msvcVersion = static_cast<MSVCVersion>(rootNode["msvcVersion"].as<int>());
+                if (rootNode["renderPassSettings"])
+                        Meta::Deserialize(&m_renderPassSettings, rootNode["renderPassSettings"]);
 		
 		return isSuccess;
 	}
@@ -190,7 +197,7 @@ private:
     bool m_isEditorMode{ true };
 	bool m_isMinimized{ false };
 	MSVCVersion m_msvcVersion{ MSVCVersion::None };
+    RenderPassSettings m_renderPassSettings{};
 	Mathf::Vector2 m_lastWindowSize{ 0.0f, 0.0f };
 };
 
-static auto& EngineSettingInstance = EngineSetting::GetInstance();

--- a/EngineEntry/RenderPassSettings.h
+++ b/EngineEntry/RenderPassSettings.h
@@ -1,0 +1,257 @@
+#pragma once
+#include "Core.Minimal.h"
+#include "ReflectionMecro.h"
+#include "../RenderEngine/ToneMapPass.h"
+
+struct AAPassSetting
+{
+    ReflectionField(AAPassSetting)
+    {
+        PropertyField
+        ({
+            meta_property(isApply)
+            meta_property(bias)
+            meta_property(biasMin)
+            meta_property(spanMax)
+        });
+        FieldEnd(AAPassSetting, PropertyOnly);
+    }
+    [[Serializable]]
+    AAPassSetting() = default;
+
+    bool isApply{ true };
+    float bias{ 0.688f };
+    float biasMin{ 0.021f };
+    float spanMax{ 8.0f };
+};
+
+struct SSAOPassSetting
+{
+    ReflectionField(SSAOPassSetting)
+    {
+        PropertyField
+        ({
+            meta_property(radius)
+            meta_property(thickness)
+        });
+        FieldEnd(SSAOPassSetting, PropertyOnly);
+    }
+    [[Serializable]]
+    SSAOPassSetting() = default;
+
+    float radius{ 0.1f };
+    float thickness{ 0.1f };
+};
+
+struct ShadowMapPassSetting
+{
+    ReflectionField(ShadowMapPassSetting)
+    {
+        PropertyField
+        ({
+            meta_property(useCascade)
+            meta_property(isCloudOn)
+            meta_property(cloudSize)
+            meta_property(cloudDirection)
+            meta_property(cloudMoveSpeed)
+            meta_property(epsilon)
+        });
+        FieldEnd(ShadowMapPassSetting, PropertyOnly);
+    }
+    [[Serializable]]
+    ShadowMapPassSetting() = default;
+
+    bool useCascade{ true };
+    bool isCloudOn{ true };
+    Mathf::Vector2 cloudSize{ 4.f, 4.f };
+    Mathf::Vector2 cloudDirection{ 1.f, 1.f };
+    float cloudMoveSpeed{ 0.0003f };
+    float epsilon{ 0.001f };
+};
+
+struct DeferredPassSetting
+{
+    ReflectionField(DeferredPassSetting)
+    {
+        PropertyField
+        ({
+            meta_property(useAmbientOcclusion)
+            meta_property(useEnvironmentMap)
+            meta_property(useLightWithShadows)
+            meta_property(envMapIntensity)
+        });
+        FieldEnd(DeferredPassSetting, PropertyOnly);
+    }
+    [[Serializable]]
+    DeferredPassSetting() = default;
+
+    bool useAmbientOcclusion{ true };
+    bool useEnvironmentMap{ true };
+    bool useLightWithShadows{ true };
+    float envMapIntensity{ 1.f };
+};
+
+struct PostProcessingPassSetting
+{
+    ReflectionField(PostProcessingPassSetting)
+    {
+        PropertyField
+        ({
+            meta_property(applyBloom)
+            meta_property(threshold)
+            meta_property(knee)
+            meta_property(coefficient)
+        });
+        FieldEnd(PostProcessingPassSetting, PropertyOnly);
+    }
+    [[Serializable]]
+    PostProcessingPassSetting() = default;
+
+    bool applyBloom{ true };
+    float threshold{ 0.3f };
+    float knee{ 0.5f };
+    float coefficient{ 0.3f };
+};
+
+struct SSGIPassSetting
+{
+    ReflectionField(SSGIPassSetting)
+    {
+        PropertyField
+        ({
+            meta_property(isOn)
+            meta_property(useOnlySSGI)
+            meta_property(useDualFilteringStep)
+            meta_property(radius)
+            meta_property(thickness)
+            meta_property(intensity)
+            meta_property(ssratio)
+        });
+        FieldEnd(SSGIPassSetting, PropertyOnly);
+    }
+    [[Serializable]]
+    SSGIPassSetting() = default;
+
+    bool isOn{ true };
+    bool useOnlySSGI{ false };
+    int useDualFilteringStep{ 2 };
+    float radius{ 4.f };
+    float thickness{ 0.5f };
+    float intensity{ 1.f };
+    int ssratio{ 4 };
+};
+
+struct VignettePassSetting
+{
+    ReflectionField(VignettePassSetting)
+    {
+        PropertyField
+        ({
+            meta_property(isOn)
+            meta_property(radius)
+            meta_property(softness)
+        });
+        FieldEnd(VignettePassSetting, PropertyOnly);
+    }
+    [[Serializable]]
+    VignettePassSetting() = default;
+
+    bool isOn{ true };
+    float radius{ 0.75f };
+    float softness{ 0.5f };
+};
+
+struct ColorGradingPassSetting
+{
+    ReflectionField(ColorGradingPassSetting)
+    {
+        PropertyField
+        ({
+            meta_property(isOn)
+            meta_property(lerp)
+        });
+        FieldEnd(ColorGradingPassSetting, PropertyOnly);
+    }
+    [[Serializable]]
+    ColorGradingPassSetting() = default;
+
+    bool isOn{ true };
+    float lerp{ 0.f };
+};
+
+struct ToneMapPassSetting
+{
+    ReflectionField(ToneMapPassSetting)
+    {
+        PropertyField
+        ({
+            meta_property(isAbleAutoExposure)
+            meta_property(isAbleToneMap)
+            meta_property(fNumber)
+            meta_property(shutterTime)
+            meta_property(ISO)
+            meta_property(exposureCompensation)
+            meta_property(speedBrightness)
+            meta_property(speedDarkness)
+            meta_property(toneMapType)
+            meta_property(filmSlope)
+            meta_property(filmToe)
+            meta_property(filmShoulder)
+            meta_property(filmBlackClip)
+            meta_property(filmWhiteClip)
+            meta_property(toneMapExposure)
+        });
+        FieldEnd(ToneMapPassSetting, PropertyOnly);
+    }
+    [[Serializable]]
+    ToneMapPassSetting() = default;
+
+    bool isAbleAutoExposure{ true };
+    bool isAbleToneMap{ true };
+    float fNumber{ 8.f };
+    float shutterTime{ 16.f };
+    float ISO{ 100.f };
+    float exposureCompensation{ 0.f };
+    float speedBrightness{ 1.5f };
+    float speedDarkness{ 0.7f };
+    ToneMapType toneMapType{ ToneMapType::ACES };
+    float filmSlope{ 0.88f };
+    float filmToe{ 0.55f };
+    float filmShoulder{ 0.26f };
+    float filmBlackClip{ 0.f };
+    float filmWhiteClip{ 0.04f };
+    float toneMapExposure{ 1.f };
+};
+
+struct RenderPassSettings
+{
+    ReflectionField(RenderPassSettings)
+    {
+        PropertyField
+        ({
+            meta_property(aa)
+            meta_property(ssao)
+            meta_property(shadow)
+            meta_property(deferred)
+            meta_property(post)
+            meta_property(ssgi)
+            meta_property(vignette)
+            meta_property(colorGrading)
+            meta_property(toneMap)
+        });
+        FieldEnd(RenderPassSettings, PropertyOnly);
+    }
+    [[Serializable]]
+    RenderPassSettings() = default;
+
+    AAPassSetting aa{};
+    SSAOPassSetting ssao{};
+    ShadowMapPassSetting shadow{};
+    DeferredPassSetting deferred{};
+    PostProcessingPassSetting post{};
+    SSGIPassSetting ssgi{};
+    VignettePassSetting vignette{};
+    ColorGradingPassSetting colorGrading{};
+    ToneMapPassSetting toneMap{};
+};
+

--- a/RenderEngine/AAPass.cpp
+++ b/RenderEngine/AAPass.cpp
@@ -1,5 +1,6 @@
 #include "AAPass.h"
 #include "ShaderSystem.h"
+#include "../EngineEntry/RenderPassSettings.h"
 #include "Material.h"
 #include "Skeleton.h"
 #include "Scene.h"
@@ -92,4 +93,12 @@ void AAPass::ControlPanel()
 		m_FXAAParameters.SpanMax = 8.0f;
 	}
 	ImGui::PopID();
+}
+
+void AAPass::ApplySettings(const AAPassSetting& setting)
+{
+    m_isApply = setting.isApply;
+    m_FXAAParameters.Bias = setting.bias;
+    m_FXAAParameters.BiasMin = setting.biasMin;
+    m_FXAAParameters.SpanMax = setting.spanMax;
 }

--- a/RenderEngine/AAPass.h
+++ b/RenderEngine/AAPass.h
@@ -14,6 +14,7 @@ struct alignas(16) FXAAParametersBuffer
 };
 
 class Camera;
+struct AAPassSetting;
 class AAPass final : public IRenderPass
 {
 public:
@@ -22,6 +23,7 @@ public:
 	void SetAntiAliasingTexture(Texture* texture) { m_AntiAliasingTexture = texture; }
 	void Execute(RenderScene& scene, Camera& camera) override;
 	void ControlPanel() override;
+        void ApplySettings(const AAPassSetting& setting);
 
 private:
 	Texture* m_CopiedTexture;

--- a/RenderEngine/ColorGradingPass.cpp
+++ b/RenderEngine/ColorGradingPass.cpp
@@ -1,5 +1,6 @@
 #include "ColorGradingPass.h"
 #include "ShaderSystem.h"
+#include "../EngineEntry/RenderPassSettings.h"
 #include "TimeSystem.h"
 
 struct alignas(16) CBData {
@@ -102,4 +103,10 @@ void ColorGradingPass::ControlPanel()
 	}
 
 	ImGui::PopID();
+}
+
+void ColorGradingPass::ApplySettings(const ColorGradingPassSetting& setting)
+{
+    isOn = setting.isOn;
+    lerp = setting.lerp;
 }

--- a/RenderEngine/ColorGradingPass.h
+++ b/RenderEngine/ColorGradingPass.h
@@ -3,6 +3,7 @@
 #include "Texture.h"
 
 class Camera;
+struct ColorGradingPassSetting;
 class ColorGradingPass final : public IRenderPass
 {
 public:
@@ -12,6 +13,7 @@ public:
 	void Initialize(const std::string_view& fileName);
 	void Execute(RenderScene& scene, Camera& camera) override;
 	void ControlPanel() override;
+        void ApplySettings(const ColorGradingPassSetting& setting);
 
 	UniqueTexturePtr m_pColorGradingTexture{};
 private:

--- a/RenderEngine/DeferredPass.cpp
+++ b/RenderEngine/DeferredPass.cpp
@@ -1,5 +1,6 @@
 #include "DeferredPass.h"
 #include "Scene.h"
+#include "../EngineEntry/RenderPassSettings.h"
 #include "LightController.h"
 #include "ShaderSystem.h"
 #include "ImGuiRegister.h"
@@ -197,4 +198,12 @@ void DeferredPass::ControlPanel()
 void DeferredPass::UseLightAndEmissiveRTV(Texture* lightEmissive)
 {
     m_LightEmissiveTexture = lightEmissive;
+}
+
+void DeferredPass::ApplySettings(const DeferredPassSetting& setting)
+{
+    m_UseAmbientOcclusion = setting.useAmbientOcclusion;
+    m_UseEnvironmentMap = setting.useEnvironmentMap;
+    m_UseLightWithShadows = setting.useLightWithShadows;
+    m_envMapIntensity = setting.envMapIntensity;
 }

--- a/RenderEngine/DeferredPass.h
+++ b/RenderEngine/DeferredPass.h
@@ -3,6 +3,7 @@
 #include "Texture.h"
 
 class Camera;
+struct DeferredPassSetting;
 class DeferredPass final : public IRenderPass
 {
 public:
@@ -15,6 +16,7 @@ public:
     void Execute(RenderScene& scene, Camera& camera) override;
     void CreateRenderCommandList(ID3D11DeviceContext* deferredContext, RenderScene& scene, Camera& camera) override;
 	void ControlPanel() override;
+        void ApplySettings(const DeferredPassSetting& setting);
 
     void UseLightAndEmissiveRTV(Texture* lightEmissive);
 private:

--- a/RenderEngine/PostProcessingPass.cpp
+++ b/RenderEngine/PostProcessingPass.cpp
@@ -1,5 +1,6 @@
 #include "PostProcessingPass.h"
 #include "ShaderSystem.h"
+#include "../EngineEntry/RenderPassSettings.h"
 #include "Scene.h"
 #include "Mesh.h"
 #include "Sampler.h"
@@ -243,4 +244,12 @@ void PostProcessingPass::GaussianBlurComputeKernel()
 
 void PostProcessingPass::Resize(uint32_t width, uint32_t height)
 {
+}
+
+void PostProcessingPass::ApplySettings(const PostProcessingPassSetting& setting)
+{
+    m_PostProcessingApply.m_Bloom = setting.applyBloom;
+    m_bloomThreshold.threshold = setting.threshold;
+    m_bloomThreshold.knee = setting.knee;
+    m_bloomComposite.coeddicient = setting.coefficient;
 }

--- a/RenderEngine/PostProcessingPass.h
+++ b/RenderEngine/PostProcessingPass.h
@@ -7,6 +7,7 @@ struct PostProcessingApply
 	bool m_Bloom{ true };
 };
 
+struct PostProcessingPassSetting;
 class PostProcessingPass final : public IRenderPass
 {
 public:
@@ -15,6 +16,7 @@ public:
 
 	void Execute(RenderScene& scene, Camera& camera) override;
 	void ControlPanel() override;
+        void ApplySettings(const PostProcessingPassSetting& setting);
 	void Resize(uint32_t width, uint32_t height) override;
 
 private:

--- a/RenderEngine/SSAOPass.cpp
+++ b/RenderEngine/SSAOPass.cpp
@@ -1,5 +1,6 @@
 #include "SSAOPass.h"
 #include "ShaderSystem.h"
+#include "../EngineEntry/RenderPassSettings.h"
 #include "Scene.h"
 #include <random>
 
@@ -152,4 +153,10 @@ void SSAOPass::ControlPanel()
 
 void SSAOPass::Resize(uint32_t width, uint32_t height)
 {
+}
+
+void SSAOPass::ApplySettings(const SSAOPassSetting& setting)
+{
+    radius = setting.radius;
+    thickness = setting.thickness;
 }

--- a/RenderEngine/SSAOPass.h
+++ b/RenderEngine/SSAOPass.h
@@ -15,6 +15,7 @@ struct alignas(16) SSAOBuffer
 	UINT m_frameIndex;
 };
 
+struct SSAOPassSetting;
 class SSAOPass final : public IRenderPass
 {
 public:
@@ -25,6 +26,7 @@ public:
 	void ReloadDSV(ID3D11ShaderResourceView* depth);
 	void Execute(RenderScene& scene, Camera& camera) override;
 	void ControlPanel() override;
+        void ApplySettings(const SSAOPassSetting& setting);
 	void Resize(uint32_t width, uint32_t height) override;
 
 private:

--- a/RenderEngine/SSGIPass.cpp
+++ b/RenderEngine/SSGIPass.cpp
@@ -1,5 +1,6 @@
 #include "SSGIPass.h"
 #include "ShaderSystem.h"
+#include "../EngineEntry/RenderPassSettings.h"
 #include "Scene.h"
 
 //#define SSGI_Ratio 1
@@ -13,9 +14,9 @@ cbuffer SSGIParams
     XMMATRIX view;
     XMMATRIX proj;
     XMMATRIX inverseProjection;
-    float2 screenSize; // È­¸é Å©±â
-    float radius; // »ùÇÃ¸µ ¹İ°æ
-    float thickness; // µÎ²²
+    float2 screenSize; // í™”ë©´ í¬ê¸°
+    float radius; // ìƒ˜í”Œë§ ë°˜ê²½
+    float thickness; // ë‘ê»˜
     UINT frameIndex;
     int ratio;
     float intensity;
@@ -326,4 +327,15 @@ void SSGIPass::ControlPanel()
 
 void SSGIPass::Resize(uint32_t width, uint32_t height)
 {
+}
+
+void SSGIPass::ApplySettings(const SSGIPassSetting& setting)
+{
+    isOn = setting.isOn;
+    useOnlySSGI = setting.useOnlySSGI;
+    useDualFilteringStep = setting.useDualFilteringStep;
+    radius = setting.radius;
+    thickness = setting.thickness;
+    intensity = setting.intensity;
+    ssratio = setting.ssratio;
 }

--- a/RenderEngine/SSGIPass.h
+++ b/RenderEngine/SSGIPass.h
@@ -2,6 +2,7 @@
 #include "IRenderPass.h"
 #include "Texture.h"
 
+struct SSGIPassSetting;
 class SSGIPass final : public IRenderPass
 {
 public:
@@ -12,6 +13,7 @@ public:
 	void Execute(RenderScene& scene, Camera& camera) override;
 	void CreateRenderCommandList(ID3D11DeviceContext* deferredContext, RenderScene& scene, Camera& camera) override;
 	void ControlPanel() override;
+        void ApplySettings(const SSGIPassSetting& setting);
 	void Resize(uint32_t width, uint32_t height) override;
 
 private:

--- a/RenderEngine/SceneRenderer.cpp
+++ b/RenderEngine/SceneRenderer.cpp
@@ -1,5 +1,6 @@
 #include "SceneRenderer.h"
 #include "DeviceState.h"
+#include "../EngineEntry/EngineSetting.h"
 #include "ShaderSystem.h"
 #include "ImGuiRegister.h"
 #include "Benchmark.hpp"
@@ -98,6 +99,7 @@ SceneRenderer::SceneRenderer(const std::shared_ptr<DirectX11::DeviceResources>& 
         m_normalTexture.get(),
 		m_diffuseTexture.get()
     );
+    m_pSSAOPass->ApplySettings(EngineSettingInstance->GetRenderPassSettings().ssao);
 
     //deferredPass
     m_pDeferredPass = std::make_unique<DeferredPass>();
@@ -108,6 +110,7 @@ SceneRenderer::SceneRenderer(const std::shared_ptr<DirectX11::DeviceResources>& 
         m_emissiveTexture.get(),
 		m_bitmaskTexture.get()
     );
+    m_pDeferredPass->ApplySettings(EngineSettingInstance->GetRenderPassSettings().deferred);
 
 	//forwardPass
 	m_pForwardPass = std::make_unique<ForwardPass>();
@@ -122,6 +125,7 @@ SceneRenderer::SceneRenderer(const std::shared_ptr<DirectX11::DeviceResources>& 
 		m_toneMappedColourTexture.get()
 	);
 
+    m_pToneMapPass->ApplySettings(EngineSettingInstance->GetRenderPassSettings().toneMap);
 	//spritePass
 	m_pSpritePass = std::make_unique<SpritePass>();
 	//m_pSpritePass->Initialize(m_toneMappedColourTexture.get());
@@ -152,10 +156,12 @@ SceneRenderer::SceneRenderer(const std::shared_ptr<DirectX11::DeviceResources>& 
 
 	//Vignette
 	m_pVignettePass = std::make_unique<VignettePass>();
+    m_pVignettePass->ApplySettings(EngineSettingInstance->GetRenderPassSettings().vignette);
 
 	//ColorGrading
 	m_pColorGradingPass = std::make_unique<ColorGradingPass>();
 	m_pColorGradingPass->Initialize(PathFinder::Relative("ColorGrading\\LUT_3.png").string());
+    m_pColorGradingPass->ApplySettings(EngineSettingInstance->GetRenderPassSettings().colorGrading);
 
 	//VolumetricFog
 	m_pVolumetricFogPass = std::make_unique<VolumetricFogPass>();
@@ -166,8 +172,10 @@ SceneRenderer::SceneRenderer(const std::shared_ptr<DirectX11::DeviceResources>& 
 
 	//AAPass
 	m_pAAPass = std::make_unique<AAPass>();
+    m_pAAPass->ApplySettings(EngineSettingInstance->GetRenderPassSettings().aa);
 
 	m_pPostProcessingPass = std::make_unique<PostProcessingPass>();
+    m_pPostProcessingPass->ApplySettings(EngineSettingInstance->GetRenderPassSettings().post);
 
 	//lightmapPass
 	m_pLightMapPass = std::make_unique<LightMapPass>();
@@ -176,6 +184,7 @@ SceneRenderer::SceneRenderer(const std::shared_ptr<DirectX11::DeviceResources>& 
 	//SSGIPass
 	m_pSSGIPass = std::make_unique<SSGIPass>();
 	m_pSSGIPass->Initialize(m_diffuseTexture.get(), m_normalTexture.get(), m_lightingTexture.get());
+    m_pSSGIPass->ApplySettings(EngineSettingInstance->GetRenderPassSettings().ssgi);
 
 	//BitmaskPass
 	m_pBitMaskPass = std::make_unique<BitMaskPass>();

--- a/RenderEngine/ShadowMapPass.cpp
+++ b/RenderEngine/ShadowMapPass.cpp
@@ -1,5 +1,6 @@
 #include "ShadowMapPass.h"
 #include "ShaderSystem.h"
+#include "../EngineEntry/RenderPassSettings.h"
 #include "Scene.h"
 #include "Mesh.h"
 #include "Sampler.h"
@@ -476,4 +477,14 @@ void ShadowMapPass::CreateRenderCommandList(ID3D11DeviceContext* defferdContext,
 	{
 		CreateCommandListNormalShadow(defferdContext, scene, camera);
 	}
+}
+
+void ShadowMapPass::ApplySettings(const ShadowMapPassSetting& setting)
+{
+    g_useCascade = setting.useCascade;
+    isCloudOn = setting.isCloudOn;
+    cloudSize = setting.cloudSize;
+    cloudDirection = setting.cloudDirection;
+    cloudMoveSpeed = setting.cloudMoveSpeed;
+    m_settingConstant._epsilon = setting.epsilon;
 }

--- a/RenderEngine/ShadowMapPass.h
+++ b/RenderEngine/ShadowMapPass.h
@@ -7,6 +7,7 @@ class Texture;
 class Scene;
 class LightController;
 
+struct ShadowMapPassSetting;
 constexpr int cascadeCount = 3;
 
 class ShadowMapPass final : public IRenderPass
@@ -22,8 +23,8 @@ public:
 	void Execute(RenderScene& scene, Camera& camera) override;
 	void CreateRenderCommandList(ID3D11DeviceContext* deferredContext, RenderScene& scene, Camera& camera) override;
 	void ControlPanel() override;
+        void ApplySettings(const ShadowMapPassSetting& setting);
 	virtual void Resize(uint32_t width, uint32_t height) override;
-
 	ComPtr<ID3D11Buffer>		m_boneBuffer;
 	D3D11_VIEWPORT				shadowViewport;
 	ShadowMapConstant			m_settingConstant;

--- a/RenderEngine/ToneMapPass.cpp
+++ b/RenderEngine/ToneMapPass.cpp
@@ -1,5 +1,6 @@
 #include "ToneMapPass.h"
 #include "ShaderSystem.h"
+#include "../EngineEntry/RenderPassSettings.h"
 #include "ImGuiRegister.h"
 #include "DeviceState.h"
 #include "Camera.h"
@@ -149,7 +150,7 @@ void ToneMapPass::Execute(RenderScene& scene, Camera& camera)
 
                     float EV100 = log2((m_fNumber * m_fNumber) / m_shutterTime * (100.0f / m_ISO));
                     float exposureManual = 1.0f / pow(2.0f, EV100 + m_exposureCompensation);
-                    float targetLuminance = 0.5f; // Áß°£ È¸»ö ±âÁØ°ª (¿øÇÏ´Â °ªÀ¸·Î Á¶Á¤ °¡´É)
+                    float targetLuminance = 0.5f; // ì¤‘ê°„ íšŒìƒ‰ ê¸°ì¤€ê°’ (ì›í•˜ëŠ” ê°’ìœ¼ë¡œ ì¡°ì • ê°€ëŠ¥)
                     float exposureAuto = targetLuminance / (luminance + 1e-4f);
 
                     float exposureFinal = exposureManual * exposureAuto;
@@ -255,4 +256,23 @@ void ToneMapPass::PrepareDownsampleTextures(uint32_t width, uint32_t height)
 
 void ToneMapPass::Resize(uint32_t width, uint32_t height)
 {
+}
+
+void ToneMapPass::ApplySettings(const ToneMapPassSetting& setting)
+{
+    m_isAbleAutoExposure = setting.isAbleAutoExposure;
+    m_isAbleToneMap = setting.isAbleToneMap;
+    m_fNumber = setting.fNumber;
+    m_shutterTime = setting.shutterTime;
+    m_ISO = setting.ISO;
+    m_exposureCompensation = setting.exposureCompensation;
+    m_speedBrightness = setting.speedBrightness;
+    m_speedDarkness = setting.speedDarkness;
+    m_toneMapType = setting.toneMapType;
+    m_toneMapConstant.filmSlope = setting.filmSlope;
+    m_toneMapConstant.filmToe = setting.filmToe;
+    m_toneMapConstant.filmShoulder = setting.filmShoulder;
+    m_toneMapConstant.filmBlackClip = setting.filmBlackClip;
+    m_toneMapConstant.filmWhiteClip = setting.filmWhiteClip;
+    m_toneMapConstant.toneMapExposure = setting.toneMapExposure;
 }

--- a/RenderEngine/ToneMapPass.h
+++ b/RenderEngine/ToneMapPass.h
@@ -23,6 +23,7 @@ cbuffer ToneMapConstant
 	float toneMapExposure{ 1.f };
 };
 
+struct ToneMapPassSetting;
 class ToneMapPass final : public IRenderPass
 {
 public:
@@ -32,6 +33,7 @@ public:
 	void ToneMapSetting(bool isAbleToneMap, ToneMapType type);
     void Execute(RenderScene& scene, Camera& camera) override;
 	void ControlPanel() override;
+        void ApplySettings(const ToneMapPassSetting& setting);
 	void PrepareDownsampleTextures(uint32_t width, uint32_t height);
 	void Resize(uint32_t width, uint32_t height) override;
 

--- a/RenderEngine/VignettePass.cpp
+++ b/RenderEngine/VignettePass.cpp
@@ -1,5 +1,6 @@
 #include "VignettePass.h"
 #include "ShaderSystem.h"
+#include "../EngineEntry/RenderPassSettings.h"
 
 struct alignas(16) CBData {
 	float radius;
@@ -90,4 +91,11 @@ void VignettePass::ControlPanel()
 	}
 
 	ImGui::PopID();
+}
+
+void VignettePass::ApplySettings(const VignettePassSetting& setting)
+{
+    isOn = setting.isOn;
+    radius = setting.radius;
+    softness = setting.softness;
 }

--- a/RenderEngine/VignettePass.h
+++ b/RenderEngine/VignettePass.h
@@ -3,6 +3,7 @@
 #include "Texture.h"
 
 class Camera;
+struct VignettePassSetting;
 class VignettePass final : public IRenderPass
 {
 public:
@@ -11,6 +12,7 @@ public:
 
 	void Execute(RenderScene& scene, Camera& camera) override;
 	void ControlPanel() override;
+        void ApplySettings(const VignettePassSetting& setting);
 private:
 	Texture* m_CopiedTexture{};
 	ComPtr<ID3D11Buffer> m_Buffer{};


### PR DESCRIPTION
## Summary
- introduce `RenderPassSettings` with reflection info for many passes
- expose settings in `EngineSetting` and serialize/deserialize them
- allow render passes to apply settings
- hook SceneRenderer to load saved settings when passes are created

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687bb899d2a4832d92eb2980844e93ef