### PR TITLE
Add search filter in hierarchy window

### DIFF
--- a/EngineGUIWindow/HierarchyWindow.h
+++ b/EngineGUIWindow/HierarchyWindow.h
@@ -1,6 +1,7 @@
 #pragma once
 #ifndef DYNAMICCPP_EXPORTS
 #include "ImGuiRegister.h"
+#include "ImGui.h"
 
 class SceneRenderer;
 class GameObject;
@@ -10,8 +11,10 @@ public:
 	HierarchyWindow(SceneRenderer* ptr);
 	~HierarchyWindow() = default;
 
-	void DrawSceneObject(const std::shared_ptr<GameObject>& obj);
+        void DrawSceneObject(const std::shared_ptr<GameObject>& obj);
+        bool PassFilterRecursive(const std::shared_ptr<GameObject>& obj);
 
-	SceneRenderer* m_sceneRenderer{ nullptr };
+        SceneRenderer* m_sceneRenderer{ nullptr };
+        ImGuiTextFilter m_searchFilter{};
 };
 #endif // !DYNAMICCPP_EXPORTS


### PR DESCRIPTION
## Summary
- enable searching game objects in Hierarchy window
- filter hierarchy items recursively and show input box for search

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880e0cdf848832dade978987d2c9497