### PR TITLE
Enable recursive prefab creation

### DIFF
--- a/ScriptBinder/Prefab.h
+++ b/ScriptBinder/Prefab.h
@@ -25,6 +25,12 @@ public:
     void SetFileGuid(const FileGuid& guid) { m_fileGuid = guid; }
 
 private:
+    static MetaYml::Node SerializeRecursive(const GameObject* obj);
+    GameObject* InstantiateRecursive(const MetaYml::Node& node,
+                                     Scene* scene,
+                                     GameObject::Index parent,
+                                     const std::string_view& overrideName = "") const;
+
     MetaYml::Node m_prefabData{};
 
     [[Property]]


### PR DESCRIPTION
## Summary
- add helper methods in Prefab to serialize and instantiate recursively
- update Prefab constructor and Instantiate to use these helpers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886ff6e3e6c832d9d4d9a5b9505a284