### PR TITLE
Add Prefab Editor with dedicated scene

### DIFF
--- a/EngineGUIWindow/MenuBarWindow.cpp
+++ b/EngineGUIWindow/MenuBarWindow.cpp
@@ -23,19 +23,19 @@ void ShowVRAMBarGraph(uint64_t usedVRAM, uint64_t budgetVRAM)
     float usagePercent = (float)usedVRAM / (float)budgetVRAM;
     ImGui::Text("VRAM Usage: %.2f MB / %.2f MB", usedVRAM / (1024.0f * 1024.0f), budgetVRAM / (1024.0f * 1024.0f));
 
-    // ¹Ù ³ôÀÌ¿Í ³Êºñ Á¤ÀÇ
+    // ë°” ë†’ì´ì™€ ë„ˆë¹„ ì •ì˜
     ImVec2 barSize = ImVec2(300, 20);
     ImVec2 cursorPos = ImGui::GetCursorScreenPos();
     ImDrawList* drawList = ImGui::GetWindowDrawList();
 
-    // ¹è°æ ¹Ù
+    // ë°°ê²½ ë°”
     drawList->AddRectFilled(cursorPos, ImVec2(cursorPos.x + barSize.x, cursorPos.y + barSize.y), IM_COL32(100, 100, 100, 255));
 
-    // »ç¿ë·® ¹Ù
+    // ì‚¬ìš©ëŸ‰ ë°”
     float fillWidth = barSize.x * usagePercent;
     drawList->AddRectFilled(cursorPos, ImVec2(cursorPos.x + fillWidth, cursorPos.y + barSize.y), IM_COL32(50, 200, 50, 255));
 
-    ImGui::Dummy(barSize); // ·¹ÀÌ¾Æ¿ô °ø°£ È®º¸
+    ImGui::Dummy(barSize); // ë ˆì´ì•„ì›ƒ ê³µê°„ í™•ë³´
 }
 
 std::string WordWrapText(const std::string& input, size_t maxLineLength)
@@ -115,9 +115,9 @@ MenuBarWindow::MenuBarWindow(SceneRenderer* ptr) :
         if (ImGui::Button("Generate LightMap"))
         {
             Camera c{};
-            // ¸Ş½¬º°·Î positionMap »ı¼º
+            // ë©”ì‰¬ë³„ë¡œ positionMap ìƒì„±
             m_pPositionMapPass->Execute(*m_renderScene, c);
-            // lightMap »ı¼º
+            // lightMap ìƒì„±
             lightMap.GenerateLightMap(m_renderScene.get(), m_pPositionMapPass, m_pLightMapPass);
 
             //m_pLightMapPass->Initialize(lightMap.lightmaps);
@@ -176,19 +176,19 @@ MenuBarWindow::MenuBarWindow(SceneRenderer* ptr) :
         if (ImGui::BeginChild("Matrix", ImVec2(0, 0), flags))
         {
             ImGui::PushStyleVar(ImGuiStyleVar_CellPadding, ImVec2(2, 2));
-            ImGui::PushStyleColor(ImGuiCol_TableBorderStrong, ImVec4(1.0f, 1.0f, 1.0f, 0.0f)); // ÁøÇÑ ÁÙ - ¹İÅõ¸í Èò»ö
-            ImGui::PushStyleColor(ImGuiCol_TableBorderLight, ImVec4(1.0f, 1.0f, 1.0f, 0.0f));  // ¿¬ÇÑ ÁÙ - ´õ Åõ¸í
+            ImGui::PushStyleColor(ImGuiCol_TableBorderStrong, ImVec4(1.0f, 1.0f, 1.0f, 0.0f)); // ì§„í•œ ì¤„ - ë°˜íˆ¬ëª… í°ìƒ‰
+            ImGui::PushStyleColor(ImGuiCol_TableBorderLight, ImVec4(1.0f, 1.0f, 1.0f, 0.0f));  // ì—°í•œ ì¤„ - ë” íˆ¬ëª…
 
             const int matrixSize = 32;
             const float checkboxSize = ImGui::GetFrameHeight();
             const float cellWidth = checkboxSize;
 
-            // ÃÑ ¿­ °³¼ö = ÀÎµ¦½º ¹øÈ£ Æ÷ÇÔÇØ¼­ 33°³
+            // ì´ ì—´ ê°œìˆ˜ = ì¸ë±ìŠ¤ ë²ˆí˜¸ í¬í•¨í•´ì„œ 33ê°œ
             if (ImGui::BeginTable("CollisionMatrixTable", matrixSize + 1,
                 ImGuiTableFlags_Borders | ImGuiTableFlags_SizingFixedFit))
             {
                 // -------------------------
-                // Ã¹ ¹øÂ° Çì´õ Çà
+                // ì²« ë²ˆì§¸ í—¤ë” í–‰
                 // -------------------------
                 ImGui::TableNextRow();
                 for (int col = -1; col < matrixSize; ++col)
@@ -197,11 +197,11 @@ MenuBarWindow::MenuBarWindow(SceneRenderer* ptr) :
                     if (col >= 0)
                         ImGui::Text("%2d", col);
                     else
-                        ImGui::Text("   "); // ÁÂ»ó´Ü ºóÄ­
+                        ImGui::Text("   "); // ì¢Œìƒë‹¨ ë¹ˆì¹¸
                 }
 
                 // -------------------------
-                // º»¹® Çà ·»´õ¸µ
+                // ë³¸ë¬¸ í–‰ ë Œë”ë§
                 // -------------------------
                 for (int row = 0; row < matrixSize; ++row)
                 {
@@ -211,7 +211,7 @@ MenuBarWindow::MenuBarWindow(SceneRenderer* ptr) :
                         ImGui::TableNextColumn();
                         if (col == -1)
                         {
-                            // Çà ¹øÈ£
+                            // í–‰ ë²ˆí˜¸
                             ImGui::Text("%2d", row);
                         }
                         else
@@ -226,7 +226,7 @@ MenuBarWindow::MenuBarWindow(SceneRenderer* ptr) :
                             }
                             else
                             {
-                                // ½Ã°¢ÀûÀ¸·Î µ¿ÀÏÇÑ Å©±â È®º¸
+                                // ì‹œê°ì ìœ¼ë¡œ ë™ì¼í•œ í¬ê¸° í™•ë³´
                                 ImGui::Dummy(ImVec2(cellWidth, checkboxSize));
                             }
 
@@ -238,7 +238,7 @@ MenuBarWindow::MenuBarWindow(SceneRenderer* ptr) :
                 ImGui::EndTable();
             }
 
-            ImGui::PopStyleColor(2); // ¼³Á¤ÇÑ 2°³ »ö»ó pop
+            ImGui::PopStyleColor(2); // ì„¤ì •í•œ 2ê°œ ìƒ‰ìƒ pop
             ImGui::PopStyleVar();
             ImGui::EndChild();
         }
@@ -246,7 +246,7 @@ MenuBarWindow::MenuBarWindow(SceneRenderer* ptr) :
         ImGui::Separator();
         if (ImGui::Button("Save"))
         {
-            //Àû¿ëµÈ Ãæµ¹ ¸Å½º¸¯½º ÀúÀå
+            //ì ìš©ëœ ì¶©ëŒ ë§¤ìŠ¤ë¦­ìŠ¤ ì €ì¥
             PhysicsManagers->SetCollisionMatrix(collisionMatrix);
             m_bCollisionMatrixWindow = false;
             ImGui::GetContext("CollisionMatrixPopup").Close();
@@ -389,12 +389,6 @@ void MenuBarWindow::RenderMenuBar()
                     m_bShowInputActionMapWindow = true;
                 }
                 
-                if (ImGui::MenuItem("Prefab Editor"))
-                {
-                    m_bShowPrefabEditorWindow = true;
-				}
-
-                ImGui::PopStyleColor();
                 ImGui::EndMenu();
             }
             ImGui::PopStyleColor();
@@ -501,30 +495,28 @@ void MenuBarWindow::RenderMenuBar()
     ShowBehaviorTreeWindow();
     ShowBlackBoardWindow();
     SHowInputActionMap();
-	ShowPrefabEditorWindow();
-    if (m_bShowProfileWindow)
     {
         ImGui::Begin(ICON_FA_CHART_BAR " FrameProfiler", &m_bShowProfileWindow);
         {
             ImGui::BringWindowToFocusFront(ImGui::GetCurrentWindow());
             ImGui::BringWindowToDisplayFront(ImGui::GetCurrentWindow());
 
-            const float vramPanelHeight = 50.0f; // VRAM ±×·¡ÇÁ ³ôÀÌ
+            const float vramPanelHeight = 50.0f; // VRAM ê·¸ë˜í”„ ë†’ì´
             const float contentWidth = ImGui::GetContentRegionAvail().x;
             const float contentHeight = ImGui::GetContentRegionAvail().y;
 
-            // À§ÂÊ: HUD
+            // ìœ„ìª½: HUD
             ImGui::BeginChild("Profiler HUD", ImVec2(contentWidth, contentHeight - vramPanelHeight), false);
             {
                 DrawProfilerHUD();
             }
             ImGui::EndChild();
 
-            // ¾Æ·¡ÂÊ: VRAM ±×·¡ÇÁ
+            // ì•„ë˜ìª½: VRAM ê·¸ë˜í”„
             ImGui::BeginChild("VRAM Panel", ImVec2(contentWidth, vramPanelHeight), false);
             {
                 auto info = m_sceneRenderer->m_deviceResources->GetVideoMemoryInfo();
-                ShowVRAMBarGraph(info.CurrentUsage, info.Budget); // °¡·Î ¸·´ë ±×·¡ÇÁ
+                ShowVRAMBarGraph(info.CurrentUsage, info.Budget); // ê°€ë¡œ ë§‰ëŒ€ ê·¸ë˜í”„
             }
             ImGui::EndChild();
         }
@@ -581,7 +573,7 @@ void MenuBarWindow::RenderMenuBar()
         isPressedShift &&
         isDownS)
     {
-        // ±âÁ¸ Save As ·ÎÁ÷ È£Ãâ
+        // ê¸°ì¡´ Save As ë¡œì§ í˜¸ì¶œ
         SceneManagers->resetSelectedObjectEvent.Broadcast();
         file::path fileName = ShowSaveFileDialog(
             L"Scene Files (*.creator)\0*.creator\0",
@@ -601,7 +593,7 @@ void MenuBarWindow::RenderMenuBar()
     }
     else if (isPressedControl && isDownS)
     {
-        // ±âÁ¸ Save ·ÎÁ÷ È£Ãâ
+        // ê¸°ì¡´ Save ë¡œì§ í˜¸ì¶œ
         SceneManagers->resetSelectedObjectEvent.Broadcast();
         std::string sceneName = SceneManagers->GetActiveScene()->m_sceneName.ToString();
         file::path fileName = PathFinder::Relative("Scenes\\" + sceneName + ".creator").wstring();
@@ -639,7 +631,7 @@ void MenuBarWindow::ShowLogWindow()
     ImGui::PushFont(m_koreanFont);
     ImGui::Begin(ICON_FA_TERMINAL " Log", &m_bShowLogWindow);
 
-    // == »ó´Ü °íÁ¤ Çì´õ ¿µ¿ª ==
+    // == ìƒë‹¨ ê³ ì • í—¤ë” ì˜ì—­ ==
     ImGui::BeginChild("LogHeader", ImVec2(0, 0),
         ImGuiChildFlags_AlwaysAutoResize | ImGuiChildFlags_AutoResizeX | ImGuiChildFlags_AutoResizeY,
         ImGuiWindowFlags_NoScrollbar);
@@ -658,7 +650,7 @@ void MenuBarWindow::ShowLogWindow()
 
     ImGui::Separator();
 
-    // == ½ºÅ©·Ñ °¡´ÉÇÑ ·Î±× ¿µ¿ª ==
+    // == ìŠ¤í¬ë¡¤ ê°€ëŠ¥í•œ ë¡œê·¸ ì˜ì—­ ==
     ImGui::BeginChild("LogScrollRegion", ImVec2(0, 0), false, ImGuiWindowFlags_AlwaysVerticalScrollbar);
     {
         if (isClear)
@@ -674,7 +666,7 @@ void MenuBarWindow::ShowLogWindow()
         float sizeX = ImGui::GetContentRegionAvail().x;
 		static bool isCopyPopupOpen = false;
 		static std::string copiedText;
-        // ÇöÀç ½ºÅ©·Ñ »óÅÂ °¨Áö
+        // í˜„ì¬ ìŠ¤í¬ë¡¤ ìƒíƒœ ê°ì§€
         bool shouldScroll = autoScroll && ImGui::GetScrollY() >= ImGui::GetScrollMaxY() - 10.0f;
 
         for (size_t i = 0; i < entries.size(); ++i)
@@ -771,53 +763,6 @@ void MenuBarWindow::ShowLightMapWindow()
     ImGui::GetContext("LightMap").Open();
 }
 
-void MenuBarWindow::ShowPrefabEditorWindow()
-{
-    static Prefab* s_prefab = nullptr;
-    static file::path prefabPath;
-    if (m_bShowPrefabEditorWindow)
-    {
-        ImGui::Begin("Prefab Editor", &m_bShowPrefabEditorWindow);
-        if (ImGui::Button("Create From Selection"))
-        {
-            GameObject* selected = SceneManagers->GetActiveScene()->m_selectedSceneObject;
-            if (selected)
-            {
-                s_prefab = PrefabUtilitys->CreatePrefab(selected);
-                prefabPath.clear();
-            }
-        }
-        ImGui::SameLine();
-        if (ImGui::Button("Load"))
-        {
-            file::path path = ShowOpenFileDialog(L"Prefab Files (*.pfb)\0*.pfb\0", L"Load Prefab", PathFinder::Relative("Prefab").wstring());
-            if (!path.empty())
-            {
-                s_prefab = PrefabUtilitys->LoadPrefab(path.string());
-                prefabPath = path.string();
-            }
-        }
-        ImGui::SameLine();
-        if (ImGui::Button("Save") && s_prefab)
-        {
-            file::path path = prefabPath.empty() ? ShowSaveFileDialog(L"Prefab Files (*.pfb)\0*.pfb\0", L"Save Prefab", PathFinder::Relative("Prefab").wstring()) : prefabPath.wstring();
-            if (!path.empty())
-            {
-                PrefabUtilitys->SavePrefab(s_prefab, path.string());
-                prefabPath = path.string();
-            }
-        }
-        if (s_prefab && ImGui::Button("Instantiate"))
-        {
-            PrefabUtilitys->InstantiatePrefab(s_prefab);
-        }
-        if (s_prefab && ImGui::Button("Apply To Instances"))
-        {
-            PrefabUtilitys->UpdateInstances(s_prefab);
-        }
-        ImGui::End();
-    }
-}
 
 ed::EditorContext* s_MenuBarBTEditorContext{ nullptr };
 
@@ -1896,9 +1841,9 @@ void MenuBarWindow::SHowInputActionMap()
         }
         ImGui::Separator();
 
-        ImGui::BeginChild("ActionMaps", ImVec2(200, 0), true); // ¿ŞÂÊ
+        ImGui::BeginChild("ActionMaps", ImVec2(200, 0), true); // ì™¼ìª½
         ImGui::Text("Action Maps");
-        ImGui::SameLine();  // ¹Ù·Î ¿·¿¡ ¹öÆ° ¹èÄ¡
+        ImGui::SameLine();  // ë°”ë¡œ ì˜†ì— ë²„íŠ¼ ë°°ì¹˜
         if (ImGui::Button("+"))
         {
             InputActionManagers->AddActionMap();
@@ -1916,7 +1861,7 @@ void MenuBarWindow::SHowInputActionMap()
                 ImGui::SetNextItemWidth(200);
                 if (ImGui::InputText("##Rename", buffer, sizeof(buffer), ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_AutoSelectAll))
                 {
-                    // ¿£ÅÍ ´­·¯¼­ ÀÌ¸§ È®Á¤
+                    // ì—”í„° ëˆŒëŸ¬ì„œ ì´ë¦„ í™•ì •
                     InputActionManagers->m_actionMaps[editingMapIndex]->m_name = buffer;
                     editingMapIndex = -1;
                 }
@@ -1992,7 +1937,7 @@ void MenuBarWindow::SHowInputActionMap()
                     ImGui::SetNextItemWidth(300);
                     if (ImGui::InputText("##Rename", buffer, sizeof(buffer), ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_AutoSelectAll))
                     {
-                        // ¿£ÅÍ ´­·¯¼­ ÀÌ¸§ È®Á¤
+                        // ì—”í„° ëˆŒëŸ¬ì„œ ì´ë¦„ í™•ì •
                         map->m_actions[editingActionIndex]->actionName = buffer;
                         editingActionIndex = -1;
                     }
@@ -2071,9 +2016,9 @@ void MenuBarWindow::SHowInputActionMap()
                 {
                     ImGui::OpenPopup("SelectInputType");
                 }
-                //value ¸é state¹«½ÃÇÏ°í pressed¸¸¹Ş°í value ¿¡ vector2¿¡ ÄÁÆ®·Ñ·¯¸é ¿Ş½ºÆ½,¿À¸¥½ºÆ½  floatÀÌ¸é ¿Ş¿À,Æ®¸®°Å¸¸ ¹Ş°Ô²û Å°º¸µå´Â ´Ù°¡´É // Å°º¸µå´Â ´Ù°¡´É 4°³¹Ş°Ô²û 0,1,2,3¼ø 
+                //value ë©´ stateë¬´ì‹œí•˜ê³  pressedë§Œë°›ê³  value ì— vector2ì— ì»¨íŠ¸ë¡¤ëŸ¬ë©´ ì™¼ìŠ¤í‹±,ì˜¤ë¥¸ìŠ¤í‹±  floatì´ë©´ ì™¼ì˜¤,íŠ¸ë¦¬ê±°ë§Œ ë°›ê²Œë” í‚¤ë³´ë“œëŠ” ë‹¤ê°€ëŠ¥ // í‚¤ë³´ë“œëŠ” ë‹¤ê°€ëŠ¥ 4ê°œë°›ê²Œë” 0,1,2,3ìˆœ 
 
-                //Key State´Â valueÅ¸ÀÔÀÏ°æ¿ì Ãâ·Âx
+                //Key StateëŠ” valueíƒ€ì…ì¼ê²½ìš° ì¶œë ¥x
                 ImGui::Text("Key State : ");
                 ImGui::SameLine();
                 if(ImGui::Button(KeyStateString(action->keystate).c_str()))
@@ -2112,7 +2057,7 @@ void MenuBarWindow::SHowInputActionMap()
                     
                     if (action->valueType == InputValueType::Float)
                     {
-                        //³ªÁß¿¡ ±¸Çö
+                        //ë‚˜ì¤‘ì— êµ¬í˜„
                     }
                     else if (action->valueType == InputValueType::Vector2)
                     {
@@ -2124,7 +2069,7 @@ void MenuBarWindow::SHowInputActionMap()
                             if (ImGui::Button("KeyBoard1"))
                             {
                                 ImGui::PopID();
-                                //Ã¹¹øÂ°Å°
+                                //ì²«ë²ˆì§¸í‚¤
                                 floatId = 0;
                                 ImGui::OpenPopup("KeyBaordButtonFloat");
                             }
@@ -2138,7 +2083,7 @@ void MenuBarWindow::SHowInputActionMap()
                             if (ImGui::Button("KeyBoard2"))
                             {
                                 ImGui::PopID();
-                                //2¹øÂ°Å°
+                                //2ë²ˆì§¸í‚¤
                                 floatId = 1;
                                 ImGui::OpenPopup("KeyBaordButtonFloat");
                             }
@@ -2152,7 +2097,7 @@ void MenuBarWindow::SHowInputActionMap()
                             if (ImGui::Button("KeyBoard3"))
                             {
                                 ImGui::PopID();
-                                //2¹øÂ°Å°
+                                //2ë²ˆì§¸í‚¤
                                 floatId = 2;
                                 ImGui::OpenPopup("KeyBaordButtonFloat");
                             }
@@ -2166,7 +2111,7 @@ void MenuBarWindow::SHowInputActionMap()
                             if (ImGui::Button("KeyBoard4"))
                             {
                                 ImGui::PopID();
-                                //2¹øÂ°Å°
+                                //2ë²ˆì§¸í‚¤
                                 floatId = 3;
                                 ImGui::OpenPopup("KeyBaordButtonFloat");
                             }
@@ -2182,7 +2127,7 @@ void MenuBarWindow::SHowInputActionMap()
                             ImGui::SameLine();
                             if (ImGui::Button(ControllerButtonString(action->m_controllerButton).c_str()))
                             {
-                                //°ÔÀÓÆĞµå´Â left ½ºÆ½ light ½ºÆ½ ¸¸ ³Ö°Ô²û
+                                //ê²Œì„íŒ¨ë“œëŠ” left ìŠ¤í‹± light ìŠ¤í‹± ë§Œ ë„£ê²Œë”
                                 ImGui::OpenPopup("ControllerButtonFlaot4");
                             }
                         }

--- a/EngineGUIWindow/MenuBarWindow.h
+++ b/EngineGUIWindow/MenuBarWindow.h
@@ -13,7 +13,6 @@ public:
     void ShowLogWindow();
 	void ShowLightMapWindow();
 	void ShowBehaviorTreeWindow();
-	void ShowPrefabEditorWindow();
 	void ShowBlackBoardWindow();
 	void SHowInputActionMap();
 private:
@@ -28,7 +27,6 @@ private:
 	bool m_bShowBehaviorTreeWindow{ false };
 	bool m_bShowBlackBoardWindow{ false };
 	bool m_bShowInputActionMapWindow{ false };
-	bool m_bShowPrefabEditorWindow{ false };
-	std::vector<std::vector<uint8_t>> collisionMatrix; //32 x 32 Çà·ÄÀ» »ç¿ëÇÏ¿© Ãæµ¹ ¸ÅÆ®¸¯½º¸¦ Ç¥½ÃÇÕ´Ï´Ù.
+	std::vector<std::vector<uint8_t>> collisionMatrix; //32 x 32 í–‰ë ¬ì„ ì‚¬ìš©í•˜ì—¬ ì¶©ëŒ ë§¤íŠ¸ë¦­ìŠ¤ë¥¼ í‘œì‹œí•©ë‹ˆë‹¤.
 };
 #endif // !DYNAMICCPP_EXPORTS

--- a/RenderEngine/DataSystem.cpp
+++ b/RenderEngine/DataSystem.cpp
@@ -1,6 +1,7 @@
 #include "DataSystem.h"
 #include "ShaderSystem.h"
 #include "Model.h"	
+#include "PrefabEditor.h"
 #include <future>
 #include <shellapi.h>
 #include <ppltasks.h>
@@ -12,7 +13,7 @@
 #include "fa.h"
 #include "ToggleUI.h"
 
-using FileTypeCharArr = std::array<std::pair<DataSystem::FileType, const char*>, 9>;
+using FileTypeCharArr = std::array<std::pair<DataSystem::FileType, const char*>, 10>;
 
 constexpr FileTypeCharArr FileTypeStringTable{{
 	{ DataSystem::FileType::Model,          "Model"				},
@@ -22,14 +23,17 @@ constexpr FileTypeCharArr FileTypeStringTable{{
 	{ DataSystem::FileType::Shader,         "Shader"			},
 	{ DataSystem::FileType::CppScript,      "CppScript"			},
 	{ DataSystem::FileType::CSharpScript,   "CSharpScript"		},
+        { DataSystem::FileType::Prefab,         "Prefab"                       },
 	{ DataSystem::FileType::Sound,          "Sound"				},
 	{ DataSystem::FileType::HDR,            "HDR"				}
 }};
 
-// °Ë»ö ÇÔ¼ö
+        else if (filepath.extension() == ".pfb")
+                return DataSystem::FileType::Prefab;
+// ê²€ìƒ‰ í•¨ìˆ˜
 constexpr const char* FileTypeToString(DataSystem::FileType type)
 {
-	// ¼±Çü °Ë»ö
+	// ì„ í˜• ê²€ìƒ‰
 	for (auto&& kv : FileTypeStringTable)
 	{
 		if (kv.first == type)
@@ -1052,6 +1056,9 @@ void DataSystem::DrawFileTile(ImTextureID iconTexture, const file::path& directo
 	case FileType::CSharpScript:
 		color = IM_COL32(255, 0, 255, 255);
 		break;
+        case FileType::Prefab:
+                color = IM_COL32(0, 128, 255, 255);
+                break;
 	case FileType::Sound:
 		color = IM_COL32(255, 255, 0, 255);
 		break;
@@ -1091,6 +1098,7 @@ void DataSystem::ForceCreateYamlMetaFile(const file::path& filepath)
 
 void DataSystem::OpenFile(const file::path& filepath)
 {
+    if(filepath.extension() == ".pfb") { PrefabEditors->Open(filepath.string()); return; }
 	HINSTANCE result = ShellExecute(NULL, L"open", filepath.c_str(), NULL, NULL, SW_SHOWNORMAL);
 
 	if ((int)result <= 32)
@@ -1112,7 +1120,7 @@ void DataSystem::OpenExplorerSelectFile(const std::filesystem::path& filePath)
 		SW_SHOWNORMAL   // nShowCmd
 	);
 
-	// ShellExecute ½ÇÆĞ ½Ã ¿À·ù ÄÚµå (0 ~ 32)
+	// ShellExecute ì‹¤íŒ¨ ì‹œ ì˜¤ë¥˜ ì½”ë“œ (0 ~ 32)
 	if ((INT_PTR)result <= 32)
 	{
 		MessageBoxW(nullptr, L"Failed to open file in Explorer.", L"Error", MB_OK | MB_ICONERROR);
@@ -1161,7 +1169,7 @@ void DataSystem::OpenSolutionAndFile(const file::path& slnPath, const file::path
 				std::this_thread::sleep_for(std::chrono::milliseconds(2));
 			}
 
-			// Visual Studio Á¾·á °¨Áö ¿Ï·á
+			// Visual Studio ì¢…ë£Œ ê°ì§€ ì™„ë£Œ
 			if (!ScriptManager->IsCompileEventInvoked())
 			{
 				ScriptManager->SetCompileEventInvoked(true);
@@ -1173,7 +1181,7 @@ void DataSystem::OpenSolutionAndFile(const file::path& slnPath, const file::path
 			CloseHandle(hProcess);
 		}).detach();
 
-		CloseHandle(pi.hThread); // ½º·¹µå´Â °ğ¹Ù·Î ´İ¾Æµµ µÊ
+		CloseHandle(pi.hThread); // ìŠ¤ë ˆë“œëŠ” ê³§ë°”ë¡œ ë‹«ì•„ë„ ë¨
 	}
 	else
 	{

--- a/RenderEngine/DataSystem.h
+++ b/RenderEngine/DataSystem.h
@@ -28,6 +28,7 @@ public:
 		Shader,
 		CppScript,
 		CSharpScript,
+                Prefab,
 		Sound,
 		HDR,
 	};
@@ -76,7 +77,7 @@ public:
     Texture* LoadMaterialTexture(const std::string_view& filePath);
 	Material* CreateMaterial();
 	SpriteFont* LoadSFont(const std::wstring_view& filePath);
-	// File Operations //ÆÄÀÏ ½Ã½ºÅÛ¿¡ Á¢±ÙÀÌ °¡´ÉÇÏ±â ‹š¹®¿¡ º¸¾È»ó ÀÌ½´°¡ ÀÖÀ» °¡´É¼º ÀÖÀ½
+	// File Operations //íŒŒì¼ ì‹œìŠ¤í…œì— ì ‘ê·¼ì´ ê°€ëŠ¥í•˜ê¸° Â‹Âšë¬¸ì— ë³´ì•ˆìƒ ì´ìŠˆê°€ ìˆì„ ê°€ëŠ¥ì„± ìˆìŒ
 	void OpenFile(const file::path& filepath);
 	void OpenExplorerSelectFile(const std::filesystem::path& filePath);
 	void OpenSolutionAndFile(const file::path& slnPath, const file::path& filepath);

--- a/ScriptBinder/PrefabEditor.cpp
+++ b/ScriptBinder/PrefabEditor.cpp
@@ -1,0 +1,81 @@
+#include "PrefabEditor.h"
+
+PrefabEditor::PrefabEditor()
+{
+    ImGui::ContextRegister("Prefab Editor", [&]() {
+        if (!m_isOpened)
+            return;
+        if (ImGui::Button("Apply & Close"))
+        {
+            Close(true);
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Close"))
+        {
+            Close(false);
+        }
+    });
+    ImGui::GetContext("Prefab Editor").Close();
+}
+
+void PrefabEditor::Open(const std::string& path)
+{
+    if (m_isOpened)
+        Close(false);
+
+    m_prefab = PrefabUtilitys->LoadPrefab(path);
+    if (!m_prefab)
+        return;
+
+    m_path = path;
+    m_prevScene = SceneManagers->GetActiveScene();
+    m_prevSceneIndex = SceneManagers->GetActiveSceneIndex();
+
+    m_editScene = Scene::CreateNewScene("PrefabEditorScene");
+    SceneManagers->GetScenes().push_back(m_editScene);
+    SceneManagers->SetActiveScene(m_editScene);
+    SceneManagers->SetActiveSceneIndex(SceneManagers->GetScenes().size() - 1);
+    activeSceneChangedEvent.Broadcast();
+    sceneLoadedEvent.Broadcast();
+
+    PrefabUtilitys->InstantiatePrefab(m_prefab);
+
+    m_isOpened = true;
+    ImGui::GetContext("Prefab Editor").Open();
+}
+
+void PrefabEditor::Close(bool apply)
+{
+    if (!m_isOpened)
+        return;
+
+    if (apply && m_editScene && m_editScene->m_SceneObjects.size() > 1)
+    {
+        auto rootObj = m_editScene->m_SceneObjects[1].get();
+        Prefab* newPrefab = PrefabUtilitys->CreatePrefab(rootObj);
+        newPrefab->SetFileGuid(m_prefab->GetFileGuid());
+        PrefabUtilitys->SavePrefab(newPrefab, m_path.string());
+        PrefabUtilitys->UpdateInstances(newPrefab);
+        delete m_prefab;
+        m_prefab = newPrefab;
+    }
+
+    sceneUnloadedEvent.Broadcast();
+    if (m_editScene)
+    {
+        m_editScene->AllDestroyMark();
+        m_editScene->OnDisable();
+        m_editScene->OnDestroy();
+        auto& scenes = SceneManagers->GetScenes();
+        std::erase_if(scenes, [&](auto* s) { return s == m_editScene; });
+        delete m_editScene;
+        m_editScene = nullptr;
+    }
+
+    SceneManagers->SetActiveSceneIndex(m_prevSceneIndex);
+    SceneManagers->SetActiveScene(m_prevScene);
+    activeSceneChangedEvent.Broadcast();
+
+    m_isOpened = false;
+    ImGui::GetContext("Prefab Editor").Close();
+}

--- a/ScriptBinder/PrefabEditor.h
+++ b/ScriptBinder/PrefabEditor.h
@@ -1,0 +1,32 @@
+#pragma once
+#ifndef DYNAMICCPP_EXPORTS
+#include "Core.Minimal.h"
+#include "Prefab.h"
+#include "PrefabUtility.h"
+#include "SceneManager.h"
+#include "ImGuiRegister.h"
+#include <filesystem>
+
+class PrefabEditor : public Singleton<PrefabEditor>
+{
+private:
+    friend class Singleton;
+    PrefabEditor();
+    ~PrefabEditor() = default;
+
+public:
+    void Open(const std::string& path);
+    void Close(bool apply = true);
+    bool IsOpened() const { return m_isOpened; }
+
+private:
+    bool m_isOpened{ false };
+    Scene* m_prevScene{ nullptr };
+    size_t m_prevSceneIndex{ 0 };
+    Scene* m_editScene{ nullptr };
+    Prefab* m_prefab{ nullptr };
+    std::filesystem::path m_path{};
+};
+
+static auto& PrefabEditors = PrefabEditor::GetInstance();
+#endif // !DYNAMICCPP_EXPORTS


### PR DESCRIPTION
## Summary
- implement `PrefabEditor` singleton to edit prefabs in an isolated scene
- integrate prefab editing with DataSystem file opener
- support new prefab file type in DataSystem
- remove old prefab editor GUI handling from MenuBarWindow

## Testing
- `echo "No tests"`

------
https://chatgpt.com/codex/tasks/task_e_6887537c74b4832d8999ea096762d6ce