### PR TITLE
Add volume profile and component

### DIFF
--- a/RenderEngine/RenderEngine.vcxproj
+++ b/RenderEngine/RenderEngine.vcxproj
@@ -338,6 +338,7 @@
     <ClInclude Include="VignettePass.h" />
     <ClInclude Include="VignettePassSetting.h" />
     <ClInclude Include="VolumetricFogPass.h" />
+    <ClInclude Include="VolumeProfile.h" />
     <ClInclude Include="WireFramePass.h" />
     <ClInclude Include="GridPass.h" />
   </ItemGroup>

--- a/RenderEngine/VolumeProfile.generated.h
+++ b/RenderEngine/VolumeProfile.generated.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#define ReflectVolumeProfile \
+ReflectionField(VolumeProfile) \
+{ \
+    PropertyField \
+    ({ \
+        meta_property(settings) \
+    }); \
+    FieldEnd(VolumeProfile, PropertyOnly) \
+};

--- a/RenderEngine/VolumeProfile.h
+++ b/RenderEngine/VolumeProfile.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "RenderPassSettings.h"
+#include "VolumeProfile.generated.h"
+
+struct VolumeProfile
+{
+    ReflectVolumeProfile
+    [[Serializable]]
+    VolumeProfile() = default;
+
+    [[Property]]
+    RenderPassSettings settings{};
+};

--- a/ScriptBinder/ScriptBinder.vcxproj
+++ b/ScriptBinder/ScriptBinder.vcxproj
@@ -177,6 +177,7 @@
     <ClCompile Include="Canvas.cpp" />
     <ClCompile Include="EffectComponent.cpp" />
     <ClCompile Include="FoliageComponent.cpp" />
+    <ClCompile Include="VolumeComponent.cpp" />
     <ClCompile Include="GameObject.cpp" />
     <ClCompile Include="HotLoadSystem.cpp" />
     <ClCompile Include="InputAction.cpp" />
@@ -209,6 +210,7 @@
     <ClInclude Include="FoliageInstance.h" />
     <ClInclude Include="FoliageType.h" />
     <ClInclude Include="FoliageComponent.h" />
+    <ClInclude Include="VolumeComponent.h" />
     <ClInclude Include="InvalidScriptComponent.h" />
     <ClInclude Include="FunctionRegistry.h" />
     <ClInclude Include="IRegistableEvent.h" />

--- a/ScriptBinder/VolumeComponent.cpp
+++ b/ScriptBinder/VolumeComponent.cpp
@@ -1,0 +1,28 @@
+#include "VolumeComponent.h"
+#include "SceneManager.h"
+#include "DataSystem.h"
+#include "EngineSetting.h"
+
+void VolumeComponent::Awake()
+{
+    m_prevSettings = EngineSettingInstance.GetRenderPassSettings();
+
+    if (m_volumeProfileGuid == nullFileGuid)
+        return;
+
+    file::path path = DataSystems->GetFilePath(m_volumeProfileGuid);
+    if (!path.empty() && file::exists(path))
+    {
+        MetaYml::Node node = MetaYml::LoadFile(path.string());
+        if (node["settings"])
+        {
+            Meta::Deserialize(&m_profile.settings, node["settings"]);
+            EngineSettingInstance.GetRenderPassSettings() = m_profile.settings;
+        }
+    }
+}
+
+void VolumeComponent::OnDestroy()
+{
+    EngineSettingInstance.GetRenderPassSettings() = m_prevSettings;
+}

--- a/ScriptBinder/VolumeComponent.generated.h
+++ b/ScriptBinder/VolumeComponent.generated.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#define ReflectVolumeComponent \
+ReflectionFieldInheritance(VolumeComponent, Component) \
+{ \
+    PropertyField \
+    ({ \
+        meta_property(m_volumeProfileGuid) \
+    }); \
+    FieldEnd(VolumeComponent, PropertyOnlyInheritance) \
+};

--- a/ScriptBinder/VolumeComponent.h
+++ b/ScriptBinder/VolumeComponent.h
@@ -1,0 +1,24 @@
+#pragma once
+#include "Core.Minimal.h"
+#include "Component.h"
+#include "VolumeProfile.h"
+#include "IRegistableEvent.h"
+#include "VolumeComponent.generated.h"
+
+class VolumeComponent : public Component, public RegistableEvent<VolumeComponent>
+{
+public:
+    ReflectVolumeComponent
+    [[Serializable(Inheritance:Component)]]
+    GENERATED_BODY(VolumeComponent)
+
+    void Awake() override;
+    void OnDestroy() override;
+
+    [[Property]]
+    FileGuid m_volumeProfileGuid{ nullFileGuid };
+
+private:
+    RenderPassSettings m_prevSettings{};
+    VolumeProfile m_profile{};
+};


### PR DESCRIPTION
## Summary
- introduce `VolumeProfile` to store render pass settings
- introduce `VolumeComponent` that applies a volume profile when active
- register new files in the project build files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888bb1e1b04832da786a1c038647fec