### PR TITLE
Fix BitFlag operator behavior

### DIFF
--- a/Utility_Framework/TypeDefinition.h
+++ b/Utility_Framework/TypeDefinition.h
@@ -102,21 +102,42 @@ public:
     }
 
     BitFlag& operator|= (flag flag) noexcept
-	{
-		m_flag |= flag;
-		return *this;
-	}
+    {
+        m_flag |= static_cast<flag>(1U << flag);
+        return *this;
+    }
 
-	BitFlag& operator&= (flag flag) noexcept
-	{
-		m_flag &= flag;
-		return *this;
-	}
+    BitFlag& operator&= (flag flag) noexcept
+    {
+        m_flag &= static_cast<flag>(1U << flag);
+        return *this;
+    }
 
     BitFlag& operator^= (flag flag) noexcept
     {
-        m_flag ^= flag;
-		return *this;
+        m_flag ^= static_cast<flag>(1U << flag);
+        return *this;
+    }
+
+    [[nodiscard]] BitFlag operator|(flag flag) const noexcept
+    {
+        BitFlag result(*this);
+        result |= flag;
+        return result;
+    }
+
+    [[nodiscard]] BitFlag operator&(flag flag) const noexcept
+    {
+        BitFlag result(*this);
+        result &= flag;
+        return result;
+    }
+
+    [[nodiscard]] BitFlag operator^(flag flag) const noexcept
+    {
+        BitFlag result(*this);
+        result ^= flag;
+        return result;
     }
 
 private:


### PR DESCRIPTION
## Summary
- correct BitFlag bitwise operators so flags are treated as bit positions
- add non-mutating bitwise operators

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688c855ec7e8832d8edf4c255aed834c