### PR TITLE
Integrate bloom extract/downsample/upsample shaders

### DIFF
--- a/Dynamic_CPP/Assets/Shaders/BloomDownSample.cs.hlsl
+++ b/Dynamic_CPP/Assets/Shaders/BloomDownSample.cs.hlsl
@@ -1,0 +1,64 @@
+#include "Sampler.hlsli"
+
+Texture2D<float4> inputTexture : register(t0);
+RWTexture2D<float4> outputTexture : register(u0);
+
+cbuffer BloomDownSampleParams : register(b0)
+{
+    float2 texelSize;
+    uint  inputTextureMipLevel;
+    uint  bloomPassIndex;
+};
+
+float luminance(float3 sourceColor)
+{
+    return dot(sourceColor, float3(0.299f, 0.587f, 0.114f));
+}
+
+float3 karisAverage(float3 sourceColorA, float3 sourceColorB, float3 sourceColorC, float3 sourceColorD)
+{
+    float A = 1.0f / (1.0f + luminance(sourceColorA));
+    float B = 1.0f / (1.0f + luminance(sourceColorB));
+    float C = 1.0f / (1.0f + luminance(sourceColorC));
+    float D = 1.0f / (1.0f + luminance(sourceColorD));
+    return (sourceColorA * A + sourceColorB * B + sourceColorC * C + sourceColorD * D) / (A + B + C + D);
+}
+
+float3 average(float3 sourceColorA, float3 sourceColorB, float3 sourceColorC, float3 sourceColorD)
+{
+    return (sourceColorA + sourceColorB + sourceColorC + sourceColorD) * 0.25f;
+}
+
+[numthreads(12, 8, 1)]
+void main(uint3 DTid : SV_DispatchThreadID)
+{
+    float2 uvCoords = (DTid.xy + 0.5f) * texelSize;
+
+    float3 A = inputTexture.SampleLevel(LinearSampler, uvCoords + float2(-2.0f, -2.0f) * texelSize, inputTextureMipLevel).xyz;
+    float3 B = inputTexture.SampleLevel(LinearSampler, uvCoords + float2( 0.0f, -2.0f) * texelSize, inputTextureMipLevel).xyz;
+    float3 C = inputTexture.SampleLevel(LinearSampler, uvCoords + float2( 2.0f, -2.0f) * texelSize, inputTextureMipLevel).xyz;
+    float3 D = inputTexture.SampleLevel(LinearSampler, uvCoords + float2(-1.0f, -1.0f) * texelSize, inputTextureMipLevel).xyz;
+    float3 E = inputTexture.SampleLevel(LinearSampler, uvCoords + float2( 1.0f, -1.0f) * texelSize, inputTextureMipLevel).xyz;
+    float3 F = inputTexture.SampleLevel(LinearSampler, uvCoords + float2(-2.0f,  0.0f) * texelSize, inputTextureMipLevel).xyz;
+    float3 G = inputTexture.SampleLevel(LinearSampler, uvCoords + float2( 0.0f,  0.0f) * texelSize, inputTextureMipLevel).xyz;
+    float3 H = inputTexture.SampleLevel(LinearSampler, uvCoords + float2( 2.0f,  0.0f) * texelSize, inputTextureMipLevel).xyz;
+    float3 I = inputTexture.SampleLevel(LinearSampler, uvCoords + float2(-1.0f,  1.0f) * texelSize, inputTextureMipLevel).xyz;
+    float3 J = inputTexture.SampleLevel(LinearSampler, uvCoords + float2( 1.0f,  1.0f) * texelSize, inputTextureMipLevel).xyz;
+    float3 K = inputTexture.SampleLevel(LinearSampler, uvCoords + float2(-2.0f,  2.0f) * texelSize, inputTextureMipLevel).xyz;
+    float3 L = inputTexture.SampleLevel(LinearSampler, uvCoords + float2( 0.0f,  2.0f) * texelSize, inputTextureMipLevel).xyz;
+    float3 M = inputTexture.SampleLevel(LinearSampler, uvCoords + float2( 2.0f,  2.0f) * texelSize, inputTextureMipLevel).xyz;
+
+    if (bloomPassIndex == 0)
+    {
+        outputTexture[DTid.xy] = float4(karisAverage(D, E, I, J), 1.0f);
+        return;
+    }
+
+    float3 centerQuad     = 0.5f   * average(D, E, I, J);
+    float3 upperLeftQuad  = 0.125f * average(A, B, F, G);
+    float3 upperRightQuad = 0.125f * average(B, G, C, H);
+    float3 lowerLeftQuad  = 0.125f * average(F, G, K, L);
+    float3 lowerRightQuad = 0.125f * average(G, L, H, M);
+
+    outputTexture[DTid.xy] = float4(centerQuad + upperLeftQuad + upperRightQuad + lowerLeftQuad + lowerRightQuad, 1.0f);
+}

--- a/Dynamic_CPP/Assets/Shaders/BloomExtract.cs.hlsl
+++ b/Dynamic_CPP/Assets/Shaders/BloomExtract.cs.hlsl
@@ -1,0 +1,34 @@
+#include "Sampler.hlsli"
+
+Texture2D<float4> inputShadingPassTexture : register(t0);
+Texture2D<float4> inputLightPassTexture   : register(t1);
+RWTexture2D<float4> outputTexture        : register(u0);
+
+cbuffer BloomBuffer : register(b0)
+{
+    float threshHold;
+    float radius; // unused here but kept for alignment/compatibility
+    float2 padding;
+};
+
+[numthreads(12, 8, 1)]
+void main(uint3 DTid : SV_DispatchThreadID)
+{
+    float width, height;
+    inputShadingPassTexture.GetDimensions(width, height);
+
+    float2 texelSize = float2(1.0f / width, 1.0f / height);
+    float2 uvCoords = (DTid.xy + 0.5f) * texelSize;
+
+    float3 color = inputShadingPassTexture.SampleLevel(LinearSampler, uvCoords, 0).xyz
+                 + inputLightPassTexture.SampleLevel(LinearSampler, uvCoords, 0).xyz;
+
+    if (dot(color, float3(0.2126f, 0.7152f, 0.0722f)) > threshHold)
+    {
+        outputTexture[DTid.xy] = float4(color, 1.0f);
+    }
+    else
+    {
+        outputTexture[DTid.xy] = float4(0.0f, 0.0f, 0.0f, 1.0f);
+    }
+}

--- a/Dynamic_CPP/Assets/Shaders/BloomUpsample.cs.hlsl
+++ b/Dynamic_CPP/Assets/Shaders/BloomUpsample.cs.hlsl
@@ -1,4 +1,46 @@
-[numthreads(1, 1, 1)]
-void main( uint3 DTid : SV_DispatchThreadID )
+#include "Sampler.hlsli"
+
+Texture2D<float4> inputPreviousUpSampleTexture : register(t0);
+Texture2D<float4> inputCurrentDownSampleTexture : register(t1);
+RWTexture2D<float4> outputCurrentUpSampleTexture : register(u0);
+
+cbuffer BloomUpSampleParams : register(b0)
 {
+    float radius;
+    uint bloomPassIndex;
+    uint inputPreviousUpSampleMipLevel;
+    uint maxBloomPasses;
+};
+
+[numthreads(12, 8, 1)]
+void main(uint3 DTid : SV_DispatchThreadID)
+{
+    float width, height;
+    outputCurrentUpSampleTexture.GetDimensions(width, height);
+    float2 outputTexelSize = 1.0f / float2(width, height);
+
+    float2 uvCoords = (DTid.xy + 0.5f) * outputTexelSize;
+
+    // Copy current downsample level
+    outputCurrentUpSampleTexture[DTid.xy] = inputCurrentDownSampleTexture.Load(int3(DTid.xy, 0));
+
+    if (bloomPassIndex == maxBloomPasses - 1)
+    {
+        return;
+    }
+
+    inputPreviousUpSampleTexture.GetDimensions(width, height);
+    float2 inputTexelSize = 1.0f / float2(width, height);
+
+    float3 A = (1.0f / 16.0f) * inputPreviousUpSampleTexture.SampleLevel(LinearSampler, uvCoords + float2(-1.0f, -1.0f) * inputTexelSize * radius, inputPreviousUpSampleMipLevel).xyz;
+    float3 B = (2.0f / 16.0f) * inputPreviousUpSampleTexture.SampleLevel(LinearSampler, uvCoords + float2( 0.0f, -1.0f) * inputTexelSize * radius, inputPreviousUpSampleMipLevel).xyz;
+    float3 C = (1.0f / 16.0f) * inputPreviousUpSampleTexture.SampleLevel(LinearSampler, uvCoords + float2( 1.0f, -1.0f) * inputTexelSize * radius, inputPreviousUpSampleMipLevel).xyz;
+    float3 D = (2.0f / 16.0f) * inputPreviousUpSampleTexture.SampleLevel(LinearSampler, uvCoords + float2(-1.0f,  0.0f) * inputTexelSize * radius, inputPreviousUpSampleMipLevel).xyz;
+    float3 E = (4.0f / 16.0f) * inputPreviousUpSampleTexture.SampleLevel(LinearSampler, uvCoords + float2( 0.0f,  0.0f) * inputTexelSize * radius, inputPreviousUpSampleMipLevel).xyz;
+    float3 F = (2.0f / 16.0f) * inputPreviousUpSampleTexture.SampleLevel(LinearSampler, uvCoords + float2( 1.0f,  0.0f) * inputTexelSize * radius, inputPreviousUpSampleMipLevel).xyz;
+    float3 G = (1.0f / 16.0f) * inputPreviousUpSampleTexture.SampleLevel(LinearSampler, uvCoords + float2(-1.0f,  1.0f) * inputTexelSize * radius, inputPreviousUpSampleMipLevel).xyz;
+    float3 H = (2.0f / 16.0f) * inputPreviousUpSampleTexture.SampleLevel(LinearSampler, uvCoords + float2( 0.0f,  1.0f) * inputTexelSize * radius, inputPreviousUpSampleMipLevel).xyz;
+    float3 I = (1.0f / 16.0f) * inputPreviousUpSampleTexture.SampleLevel(LinearSampler, uvCoords + float2( 1.0f,  1.0f) * inputTexelSize * radius, inputPreviousUpSampleMipLevel).xyz;
+
+    outputCurrentUpSampleTexture[DTid.xy] += float4(A + B + C + D + E + F + G + H + I, 1.0f);
 }

--- a/RenderEngine/RenderEngine.vcxproj
+++ b/RenderEngine/RenderEngine.vcxproj
@@ -550,6 +550,21 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='GameBuild|x64'">true</ExcludedFromBuild>
     </FxCompile>
+    <FxCompile Include="..\Dynamic_CPP\Assets\Shaders\BloomDownSample.cs.hlsl">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='GameBuild|x64'">true</ExcludedFromBuild>
+    </FxCompile>
+    <FxCompile Include="..\Dynamic_CPP\Assets\Shaders\BloomExtract.cs.hlsl">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='GameBuild|x64'">true</ExcludedFromBuild>
+    </FxCompile>
+    <FxCompile Include="..\Dynamic_CPP\Assets\Shaders\BloomUpsample.cs.hlsl">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='GameBuild|x64'">true</ExcludedFromBuild>
+    </FxCompile>
     <FxCompile Include="..\Dynamic_CPP\Assets\Shaders\ColorGrading.ps.hlsl">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='GameBuild|x64'">true</ExcludedFromBuild>

--- a/RenderEngine/RenderEngine.vcxproj.filters
+++ b/RenderEngine/RenderEngine.vcxproj.filters
@@ -879,6 +879,15 @@
     <FxCompile Include="..\Dynamic_CPP\Assets\Shaders\BloomThresholdDownsample.cs.hlsl">
       <Filter>Shaders\PostProcessShader</Filter>
     </FxCompile>
+    <FxCompile Include="..\Dynamic_CPP\Assets\Shaders\BloomDownSample.cs.hlsl">
+      <Filter>Shaders\PostProcessShader</Filter>
+    </FxCompile>
+    <FxCompile Include="..\Dynamic_CPP\Assets\Shaders\BloomExtract.cs.hlsl">
+      <Filter>Shaders\PostProcessShader</Filter>
+    </FxCompile>
+    <FxCompile Include="..\Dynamic_CPP\Assets\Shaders\BloomUpsample.cs.hlsl">
+      <Filter>Shaders\PostProcessShader</Filter>
+    </FxCompile>
     <FxCompile Include="..\Dynamic_CPP\Assets\Shaders\FXAA.cs.hlsl">
       <Filter>Shaders\PostProcessShader</Filter>
     </FxCompile>


### PR DESCRIPTION
## Summary
- add bloom downsample, extract, and upsample compute shaders using engine bindings
- register new shaders with the RenderEngine project files

## Testing
- `msbuild RenderEngine/RenderEngine.vcxproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2bdc522a8832dac14325c9bcad6fd