### PR TITLE
Refactor bloom post-processing

### DIFF
--- a/RenderEngine/PostProcessingPass.cpp
+++ b/RenderEngine/PostProcessingPass.cpp
@@ -6,355 +6,287 @@
 #include "Sampler.h"
 #include <string>
 
-#pragma warning(disable: 2398)
 PostProcessingPass::PostProcessingPass()
 {
-	m_pso = std::make_unique<PipelineStateObject>();
+    m_pso = std::make_unique<PipelineStateObject>();
 
-	auto linearSampler = std::make_shared<Sampler>(D3D11_FILTER_MIN_MAG_MIP_LINEAR, D3D11_TEXTURE_ADDRESS_CLAMP);
-	auto pointSampler  = std::make_shared<Sampler>(D3D11_FILTER_MIN_MAG_MIP_POINT, D3D11_TEXTURE_ADDRESS_CLAMP);
-	m_pso->m_samplers.push_back(linearSampler);
-	m_pso->m_samplers.push_back(pointSampler);
-	m_pso->m_primitiveTopology = D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP;
+    auto linearSampler = std::make_shared<Sampler>(D3D11_FILTER_MIN_MAG_MIP_LINEAR, D3D11_TEXTURE_ADDRESS_CLAMP);
+    auto pointSampler  = std::make_shared<Sampler>(D3D11_FILTER_MIN_MAG_MIP_POINT, D3D11_TEXTURE_ADDRESS_CLAMP);
+    m_pso->m_samplers.push_back(linearSampler);
+    m_pso->m_samplers.push_back(pointSampler);
+    m_pso->m_primitiveTopology = D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP;
 
-	m_pso->m_vertexShader = &ShaderSystem->VertexShaders["Fullscreen"];
-	m_pBloomDownSampledCS = &ShaderSystem->ComputeShaders["BloomThresholdDownsample"];
-	m_pGaussianBlurCS = &ShaderSystem->ComputeShaders["GaussianBlur"];
-	m_pBloomCompositePS = &ShaderSystem->PixelShaders["BloomComposite"];
+    m_pso->m_vertexShader = &ShaderSystem->VertexShaders["Fullscreen"];
+    m_pBloomCompositePS = &ShaderSystem->PixelShaders["BloomComposite"];
+    m_pBloomExtractCS   = &ShaderSystem->ComputeShaders["BloomExtract"];
+    m_pBloomDownSampleCS = &ShaderSystem->ComputeShaders["BloomDownSample"];
+    m_pBloomUpSampleCS  = &ShaderSystem->ComputeShaders["BloomUpSample"];
 
-	InputLayOutContainer vertexLayoutDesc = {
-		{ "POSITION",     0, DXGI_FORMAT_R32G32B32_FLOAT,    0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 },
-		{ "NORMAL",       0, DXGI_FORMAT_R32G32B32_FLOAT,    0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 },
-		{ "TEXCOORD",     0, DXGI_FORMAT_R32G32_FLOAT,       0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 },
-		{ "TEXCOORD",     1, DXGI_FORMAT_R32G32_FLOAT,       0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 },
-		{ "TANGENT",      0, DXGI_FORMAT_R32G32B32_FLOAT,    0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 },
-		{ "BINORMAL",     0, DXGI_FORMAT_R32G32B32_FLOAT,    0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 },
-		{ "BLENDINDICES", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 },
-		{ "BLENDWEIGHT",  0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 },
-	};
-	m_pso->CreateInputLayout(std::move(vertexLayoutDesc));
+    InputLayOutContainer vertexLayoutDesc = {
+        { "POSITION",     0, DXGI_FORMAT_R32G32B32_FLOAT,    0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+        { "NORMAL",       0, DXGI_FORMAT_R32G32B32_FLOAT,    0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+        { "TEXCOORD",     0, DXGI_FORMAT_R32G32_FLOAT,       0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+        { "TEXCOORD",     1, DXGI_FORMAT_R32G32_FLOAT,       0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+        { "TANGENT",      0, DXGI_FORMAT_R32G32B32_FLOAT,    0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+        { "BINORMAL",     0, DXGI_FORMAT_R32G32B32_FLOAT,    0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+        { "BLENDINDICES", 0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+        { "BLENDWEIGHT",  0, DXGI_FORMAT_R32G32B32A32_FLOAT, 0, D3D11_APPEND_ALIGNED_ELEMENT, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+    };
+    m_pso->CreateInputLayout(std::move(vertexLayoutDesc));
 
-	CD3D11_RASTERIZER_DESC rasterizerDesc{ CD3D11_DEFAULT() };
+    CD3D11_RASTERIZER_DESC rasterizerDesc{ CD3D11_DEFAULT() };
+    DirectX11::ThrowIfFailed(
+        DeviceState::g_pDevice->CreateRasterizerState(
+            &rasterizerDesc,
+            &m_pso->m_rasterizerState));
 
-	DirectX11::ThrowIfFailed(
-		DeviceState::g_pDevice->CreateRasterizerState(
-			&rasterizerDesc,
-			&m_pso->m_rasterizerState
-		)
-	);
+    TextureInitialization();
 
-	TextureInitialization();
-	GaussianBlurComputeKernel();
-
-	m_bloomThresholdBuffer	= DirectX11::CreateBuffer(sizeof(ThresholdParams), D3D11_BIND_CONSTANT_BUFFER, &m_bloomThreshold);
-	m_bloomBlurBuffer		= DirectX11::CreateBuffer(sizeof(BlurParams), D3D11_BIND_CONSTANT_BUFFER, &m_bloomBlur);
-	m_bloomCompositeBuffer	= DirectX11::CreateBuffer(sizeof(BloomCompositeParams), D3D11_BIND_CONSTANT_BUFFER, &m_bloomComposite);
+    m_bloomParamBuffer      = DirectX11::CreateBuffer(sizeof(BloomParams), D3D11_BIND_CONSTANT_BUFFER, &m_bloomParams);
+    m_downSampleBuffer      = DirectX11::CreateBuffer(sizeof(BloomDownSampleParams), D3D11_BIND_CONSTANT_BUFFER, nullptr);
+    m_upSampleBuffer        = DirectX11::CreateBuffer(sizeof(BloomUpSampleParams), D3D11_BIND_CONSTANT_BUFFER, nullptr);
+    m_bloomCompositeBuffer  = DirectX11::CreateBuffer(sizeof(BloomCompositeParams), D3D11_BIND_CONSTANT_BUFFER, &m_bloomComposite);
 }
 
 PostProcessingPass::~PostProcessingPass()
 {
-        delete m_CopiedTexture;
-        for (auto* tex : m_bloomMipTextures)
-        {
-                delete tex;
-        }
-        for (auto* tex : m_bloomTempTextures)
-        {
-                delete tex;
-        }
-        delete m_BloomResult;
+    delete m_CopiedTexture;
+    delete m_bloomExtractTexture;
+    for (auto* tex : m_bloomDownSampledTextures)
+    {
+        delete tex;
+    }
+    for (auto* tex : m_bloomUpSampledTextures)
+    {
+        delete tex;
+    }
+    delete m_BloomResult;
 }
 
 void PostProcessingPass::Execute(RenderScene& scene, Camera& camera)
 {
-	if (!RenderPassData::VaildCheck(&camera)) return;
-	auto renderData = RenderPassData::GetData(&camera);
-	// Copy the back buffer to a texture
-	PrepaerShaderState();
+    if (!RenderPassData::VaildCheck(&camera)) return;
+    auto renderData = RenderPassData::GetData(&camera);
+    PrepaerShaderState();
 
-	DirectX11::CopyResource(m_CopiedTexture->m_pTexture, renderData->m_renderTarget->m_pTexture);
+    DirectX11::CopyResource(m_CopiedTexture->m_pTexture, renderData->m_renderTarget->m_pTexture);
 
-	if (m_PostProcessingApply.m_Bloom)
-	{
-		BloomPass(scene, camera);
-	}
+    if (m_PostProcessingApply.m_Bloom)
+    {
+        BloomPass(scene, camera);
+    }
 
-	DirectX11::CopyResource(renderData->m_renderTarget->m_pTexture, m_CopiedTexture->m_pTexture);
+    DirectX11::CopyResource(renderData->m_renderTarget->m_pTexture, m_CopiedTexture->m_pTexture);
 }
 
 void PostProcessingPass::ControlPanel()
 {
-	ImGui::PushID(this);
-	auto& setting = EngineSettingInstance->GetRenderPassSettingsRW().bloom;
+    ImGui::PushID(this);
+    auto& setting = EngineSettingInstance->GetRenderPassSettingsRW().bloom;
 
-	if (ImGui::Checkbox("ApplyBloom",   &m_PostProcessingApply.m_Bloom))
-	{
-		setting.applyBloom = m_PostProcessingApply.m_Bloom;
-	}
-	if (ImGui::DragFloat("Threshold",   &m_bloomThreshold.threshold))
-	{
-		setting.threshold = m_bloomThreshold.threshold;
-	}
-	if (ImGui::DragFloat("Knee",                &m_bloomThreshold.knee))
-	{
-		setting.knee = m_bloomThreshold.knee;
-	}
-	if (ImGui::DragFloat("Coefficient", &m_bloomComposite.coefficient))
-	{
-		setting.coefficient = m_bloomComposite.coefficient;
-	}
-	if (ImGui::DragInt("BlurRadius", &m_bloomBlur.radius, 1.f, 1, GAUSSIAN_BLUR_RADIUS))
-	{
-		GaussianBlurComputeKernel();
-	}
-	if (ImGui::DragFloat("BlurSigma", &m_bloomBlur.sigma, 0.1f, 0.1f, 20.0f))
-	{
-		GaussianBlurComputeKernel();
-	}
-
-    if (ImGui::Button("Reset")) {
-            m_bloomThreshold.threshold = 0.3f;
-            m_bloomThreshold.knee = 0.5f;
-            m_bloomComposite.coefficient = 0.3f;
-            m_bloomBlur.radius = 7;
-            m_bloomBlur.sigma = 5.f;
-            GaussianBlurComputeKernel();
-            setting.applyBloom = true;
-            setting.threshold = m_bloomThreshold.threshold;
-            setting.knee = m_bloomThreshold.knee;
-            setting.coefficient = m_bloomComposite.coefficient;
-            setting.blurRadius = m_bloomBlur.radius;
-            setting.blurSigma = m_bloomBlur.sigma;
+    if (ImGui::Checkbox("ApplyBloom", &m_PostProcessingApply.m_Bloom))
+    {
+        setting.applyBloom = m_PostProcessingApply.m_Bloom;
     }
-	ImGui::PopID();
-
+    if (ImGui::DragFloat("Threshold", &m_bloomParams.threshHold, 0.1f, 0.f, 50.f))
+    {
+        setting.threshold = m_bloomParams.threshHold;
+    }
+    if (ImGui::DragFloat("Radius", &m_bloomParams.radius, 0.1f, 0.f, 10.f))
+    {
+        setting.blurSigma = m_bloomParams.radius;
+    }
+    if (ImGui::DragFloat("Coefficient", &m_bloomComposite.coefficient, 0.01f, 0.f, 2.f))
+    {
+        setting.coefficient = m_bloomComposite.coefficient;
+    }
+    if (ImGui::Button("Reset"))
+    {
+        m_bloomParams.threshHold = 5.f;
+        m_bloomParams.radius = 2.f;
+        m_bloomComposite.coefficient = 0.05f;
+        setting.applyBloom = true;
+        setting.threshold = m_bloomParams.threshHold;
+        setting.blurSigma = m_bloomParams.radius;
+        setting.coefficient = m_bloomComposite.coefficient;
+    }
+    ImGui::PopID();
 }
 
 void PostProcessingPass::ApplySettings(const BloomPassSetting& setting)
 {
-	m_PostProcessingApply.m_Bloom = setting.applyBloom;
-	m_bloomThreshold.threshold = setting.threshold;
-	m_bloomThreshold.knee = setting.knee;
-	m_bloomComposite.coefficient = setting.coefficient;
-	m_bloomBlur.radius = setting.blurRadius;
-	m_bloomBlur.sigma = setting.blurSigma;
-	GaussianBlurComputeKernel();
+    m_PostProcessingApply.m_Bloom = setting.applyBloom;
+    m_bloomParams.threshHold = setting.threshold;
+    m_bloomParams.radius = setting.blurSigma;
+    m_bloomComposite.coefficient = setting.coefficient;
 }
 
 void PostProcessingPass::PrepaerShaderState()
 {
-	m_pBloomDownSampledCS = &ShaderSystem->ComputeShaders["BloomThresholdDownsample"];
-	m_pGaussianBlurCS = &ShaderSystem->ComputeShaders["GaussianBlur"];
-	m_pBloomCompositePS = &ShaderSystem->PixelShaders["BloomComposite"];
+    m_pBloomCompositePS = &ShaderSystem->PixelShaders["BloomComposite"];
+    m_pBloomExtractCS   = &ShaderSystem->ComputeShaders["BloomExtract"];
+    m_pBloomDownSampleCS = &ShaderSystem->ComputeShaders["BloomDownSample"];
+    m_pBloomUpSampleCS  = &ShaderSystem->ComputeShaders["BloomUpSample"];
 }
 
 void PostProcessingPass::TextureInitialization()
 {
-        //Bloom Pass
-        BloomBufferWidth = DeviceState::g_ClientRect.width / 2;
-        BloomBufferHeight = DeviceState::g_ClientRect.height / 2;
+    m_CopiedTexture = Texture::Create(
+        DeviceState::g_ClientRect.width,
+        DeviceState::g_ClientRect.height,
+        "CopiedTexture",
+        DXGI_FORMAT_R16G16B16A16_FLOAT,
+        D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET);
+    m_CopiedTexture->CreateRTV(DXGI_FORMAT_R16G16B16A16_FLOAT);
+    m_CopiedTexture->CreateSRV(DXGI_FORMAT_R16G16B16A16_FLOAT);
+    m_CopiedTexture->m_textureType = TextureType::ImageTexture;
 
-        m_CopiedTexture = Texture::Create(
-                DeviceState::g_ClientRect.width,
-                DeviceState::g_ClientRect.height,
-                "CopiedTexture",
-                DXGI_FORMAT_R16G16B16A16_FLOAT,
-                D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET
-        );
-        m_CopiedTexture->CreateRTV(DXGI_FORMAT_R16G16B16A16_FLOAT);
-        m_CopiedTexture->CreateSRV(DXGI_FORMAT_R16G16B16A16_FLOAT);
-        m_CopiedTexture->m_textureType = TextureType::ImageTexture;
+    m_bloomExtractTexture = Texture::Create(
+        DeviceState::g_ClientRect.width,
+        DeviceState::g_ClientRect.height,
+        "BloomExtract",
+        DXGI_FORMAT_R16G16B16A16_FLOAT,
+        D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS);
+    m_bloomExtractTexture->CreateSRV(DXGI_FORMAT_R16G16B16A16_FLOAT);
+    m_bloomExtractTexture->CreateUAV(DXGI_FORMAT_R16G16B16A16_FLOAT);
+    m_bloomExtractTexture->m_textureType = TextureType::ImageTexture;
 
-        for (uint32_t i = 0; i < BLOOM_MIP_LEVELS; ++i)
-        {
-                uint32_t ratio = 1u << (i + 1); // 2,4,8,16
-                std::string name = "BloomMip" + std::to_string(i);
-                m_bloomMipTextures[i] = Texture::Create(
-                        ratio,
-                        ratio,
-                        DeviceState::g_ClientRect.width,
-                        DeviceState::g_ClientRect.height,
-                        name,
-                        DXGI_FORMAT_R16G16B16A16_FLOAT,
-                        D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS | D3D11_BIND_RENDER_TARGET
-                );
-                m_bloomMipTextures[i]->CreateSRV(DXGI_FORMAT_R16G16B16A16_FLOAT);
-                m_bloomMipTextures[i]->CreateUAV(DXGI_FORMAT_R16G16B16A16_FLOAT);
-                m_bloomMipTextures[i]->CreateRTV(DXGI_FORMAT_R16G16B16A16_FLOAT);
-                m_bloomMipTextures[i]->m_textureType = TextureType::ImageTexture;
+    for (uint32_t i = 0; i < BLOOM_MIP_LEVELS; ++i)
+    {
+        uint32_t ratio = 1u << (i + 1);
+        std::string downName = "BloomDownSample" + std::to_string(i);
+        m_bloomDownSampledTextures[i] = Texture::Create(
+            ratio, ratio,
+            DeviceState::g_ClientRect.width,
+            DeviceState::g_ClientRect.height,
+            downName,
+            DXGI_FORMAT_R16G16B16A16_FLOAT,
+            D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS);
+        m_bloomDownSampledTextures[i]->CreateSRV(DXGI_FORMAT_R16G16B16A16_FLOAT);
+        m_bloomDownSampledTextures[i]->CreateUAV(DXGI_FORMAT_R16G16B16A16_FLOAT);
+        m_bloomDownSampledTextures[i]->m_textureType = TextureType::ImageTexture;
 
-                std::string tempName = "BloomTemp" + std::to_string(i);
-                m_bloomTempTextures[i] = Texture::Create(
-                        ratio,
-                        ratio,
-                        DeviceState::g_ClientRect.width,
-                        DeviceState::g_ClientRect.height,
-                        tempName,
-                        DXGI_FORMAT_R16G16B16A16_FLOAT,
-                        D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS | D3D11_BIND_RENDER_TARGET
-                );
-                m_bloomTempTextures[i]->CreateSRV(DXGI_FORMAT_R16G16B16A16_FLOAT);
-                m_bloomTempTextures[i]->CreateUAV(DXGI_FORMAT_R16G16B16A16_FLOAT);
-                m_bloomTempTextures[i]->CreateRTV(DXGI_FORMAT_R16G16B16A16_FLOAT);
-                m_bloomTempTextures[i]->m_textureType = TextureType::ImageTexture;
-        }
+        std::string upName = "BloomUpSample" + std::to_string(i);
+        m_bloomUpSampledTextures[i] = Texture::Create(
+            ratio, ratio,
+            DeviceState::g_ClientRect.width,
+            DeviceState::g_ClientRect.height,
+            upName,
+            DXGI_FORMAT_R16G16B16A16_FLOAT,
+            D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_UNORDERED_ACCESS);
+        m_bloomUpSampledTextures[i]->CreateSRV(DXGI_FORMAT_R16G16B16A16_FLOAT);
+        m_bloomUpSampledTextures[i]->CreateUAV(DXGI_FORMAT_R16G16B16A16_FLOAT);
+        m_bloomUpSampledTextures[i]->m_textureType = TextureType::ImageTexture;
+    }
 
-        m_BloomResult = Texture::Create(
-                DeviceState::g_ClientRect.width,
-                DeviceState::g_ClientRect.height,
-                "BloomResult",
-                DXGI_FORMAT_R16G16B16A16_FLOAT,
-                D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET
-        );
-        m_BloomResult->CreateRTV(DXGI_FORMAT_R16G16B16A16_FLOAT);
-        m_BloomResult->CreateSRV(DXGI_FORMAT_R16G16B16A16_FLOAT);
-        m_BloomResult->m_textureType = TextureType::ImageTexture;
-
+    m_BloomResult = Texture::Create(
+        DeviceState::g_ClientRect.width,
+        DeviceState::g_ClientRect.height,
+        "BloomResult",
+        DXGI_FORMAT_R16G16B16A16_FLOAT,
+        D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET);
+    m_BloomResult->CreateRTV(DXGI_FORMAT_R16G16B16A16_FLOAT);
+    m_BloomResult->CreateSRV(DXGI_FORMAT_R16G16B16A16_FLOAT);
+    m_BloomResult->m_textureType = TextureType::ImageTexture;
 }
 
-void PostProcessingPass::BloomPass(RenderScene& scene, Camera& camera)
+void PostProcessingPass::BloomPass(RenderScene& /*scene*/, Camera& /*camera*/)
 {
-        //m_pso->m_vertexShader = m_pFullScreenVS;
-        m_pso->m_pixelShader = m_pBloomCompositePS;
+    const UINT offsets[]{ 0 };
+    constexpr ID3D11ShaderResourceView* nullSRVs[2] = { nullptr, nullptr };
+    constexpr ID3D11ShaderResourceView* nullSRV = nullptr;
+    constexpr ID3D11UnorderedAccessView* nullUAV = nullptr;
 
-        m_pso->Apply();
+    // Extract bright areas
+    DirectX11::UpdateBuffer(m_bloomParamBuffer.Get(), &m_bloomParams);
+    DirectX11::CSSetShader(m_pBloomExtractCS->GetShader(), 0, 0);
+    ID3D11ShaderResourceView* extractSRVs[2] = { m_CopiedTexture->m_pSRV, m_CopiedTexture->m_pSRV };
+    DirectX11::CSSetShaderResources(0, 2, extractSRVs);
+    DirectX11::CSSetUnorderedAccessViews(0, 1, &m_bloomExtractTexture->m_pUAV, offsets);
+    DirectX11::CSSetConstantBuffer(0, 1, m_bloomParamBuffer.GetAddressOf());
+    UINT gx = (DeviceState::g_ClientRect.width + 11) / 12;
+    UINT gy = (DeviceState::g_ClientRect.height + 7) / 8;
+    DirectX11::Dispatch(gx, gy, 1);
+    DirectX11::CSSetShaderResources(0, 2, nullSRVs);
+    DirectX11::CSSetUnorderedAccessViews(0, 1, &nullUAV, offsets);
 
-        const UINT offsets[]{ 0 };
-        constexpr ID3D11RenderTargetView* nullRTV = nullptr;
-        constexpr ID3D11ShaderResourceView* nullSRV = nullptr;
-        constexpr ID3D11UnorderedAccessView* nullUAV = nullptr;
+    // Downsample chain
+    ID3D11ShaderResourceView* currentSRV = m_bloomExtractTexture->m_pSRV;
+    for (uint32_t i = 0; i < BLOOM_MIP_LEVELS; ++i)
+    {
+        uint32_t inputWidth = DeviceState::g_ClientRect.width >> i;
+        uint32_t inputHeight = DeviceState::g_ClientRect.height >> i;
+        uint32_t width = inputWidth >> 1;
+        uint32_t height = inputHeight >> 1;
+        if (width == 0 || height == 0) break;
 
-        // Downsample chain
-        DirectX11::UpdateBuffer(m_bloomThresholdBuffer.Get(), &m_bloomThreshold);
-        ID3D11ShaderResourceView* currentSRV = m_CopiedTexture->m_pSRV;
-        for (uint32_t i = 0; i < BLOOM_MIP_LEVELS; ++i)
-        {
-                uint32_t width = DeviceState::g_ClientRect.width >> (i + 1);
-                uint32_t height = DeviceState::g_ClientRect.height >> (i + 1);
-                UINT groupX = (width + 15) / 16;
-                UINT groupY = (height + 15) / 16;
+        m_downSampleParams.texelSize = { 1.f / static_cast<float>(inputWidth), 1.f / static_cast<float>(inputHeight) };
+        m_downSampleParams.inputTextureMipLevel = 0;
+        m_downSampleParams.bloomPassIndex = i;
+        DirectX11::UpdateBuffer(m_downSampleBuffer.Get(), &m_downSampleParams);
 
-                DirectX11::CSSetShader(m_pBloomDownSampledCS->GetShader(), 0, 0);
-                DirectX11::CSSetShaderResources(0, 1, &currentSRV);
-                DirectX11::CSSetUnorderedAccessViews(0, 1, &m_bloomMipTextures[i]->m_pUAV, offsets);
-                DirectX11::CSSetConstantBuffer(0, 1, m_bloomThresholdBuffer.GetAddressOf());
+        DirectX11::CSSetShader(m_pBloomDownSampleCS->GetShader(), 0, 0);
+        DirectX11::CSSetShaderResources(0, 1, &currentSRV);
+        DirectX11::CSSetUnorderedAccessViews(0, 1, &m_bloomDownSampledTextures[i]->m_pUAV, offsets);
+        DirectX11::CSSetConstantBuffer(0, 1, m_downSampleBuffer.GetAddressOf());
 
-                DirectX11::Dispatch(groupX, groupY, 1);
+        UINT dgx = (width + 11) / 12;
+        UINT dgy = (height + 7) / 8;
+        DirectX11::Dispatch(dgx, dgy, 1);
 
-                DirectX11::CSSetShaderResources(0, 1, &nullSRV);
-                DirectX11::CSSetUnorderedAccessViews(0, 1, &nullUAV, offsets);
+        DirectX11::CSSetShaderResources(0, 1, &nullSRV);
+        DirectX11::CSSetUnorderedAccessViews(0, 1, &nullUAV, offsets);
 
-                currentSRV = m_bloomMipTextures[i]->m_pSRV;
-        }
+        currentSRV = m_bloomDownSampledTextures[i]->m_pSRV;
+    }
 
-        // Blur each mip level
-        DirectX11::CSSetShader(m_pGaussianBlurCS->GetShader(), 0, 0);
-        DirectX11::CSSetConstantBuffer(0, 1, m_bloomBlurBuffer.GetAddressOf());
-        for (uint32_t i = 0; i < BLOOM_MIP_LEVELS; ++i)
-        {
-                uint32_t width = DeviceState::g_ClientRect.width >> (i + 1);
-                uint32_t height = DeviceState::g_ClientRect.height >> (i + 1);
-                UINT groupX = (width + 15) / 16;
-                UINT groupY = (height + 15) / 16;
+    // Upsample chain
+    for (int i = static_cast<int>(BLOOM_MIP_LEVELS) - 1; i >= 0; --i)
+    {
+        m_upSampleParams.radius = m_bloomParams.radius;
+        m_upSampleParams.bloomPassIndex = static_cast<uint32_t>(i);
+        m_upSampleParams.inputPreviousUpSampleMipLevel = 0;
+        m_upSampleParams.maxBloomPasses = BLOOM_MIP_LEVELS;
+        DirectX11::UpdateBuffer(m_upSampleBuffer.Get(), &m_upSampleParams);
 
-                ID3D11ShaderResourceView* srvPing[]{ m_bloomMipTextures[i]->m_pSRV, m_bloomTempTextures[i]->m_pSRV };
-                ID3D11UnorderedAccessView* uavPing[]{ m_bloomTempTextures[i]->m_pUAV, m_bloomMipTextures[i]->m_pUAV };
+        ID3D11ShaderResourceView* upSRVs[2] = {
+            (i == static_cast<int>(BLOOM_MIP_LEVELS) - 1) ? m_bloomDownSampledTextures[static_cast<size_t>(i)]->m_pSRV : m_bloomUpSampledTextures[static_cast<size_t>(i + 1)]->m_pSRV,
+            m_bloomDownSampledTextures[static_cast<size_t>(i)]->m_pSRV };
 
-                for (uint32_t dir = 0; dir < 2; ++dir)
-                {
-                        m_bloomBlur.direction = dir;
-                        DirectX11::UpdateBuffer(m_bloomBlurBuffer.Get(), &m_bloomBlur);
+        DirectX11::CSSetShader(m_pBloomUpSampleCS->GetShader(), 0, 0);
+        DirectX11::CSSetShaderResources(0, 2, upSRVs);
+        DirectX11::CSSetUnorderedAccessViews(0, 1, &m_bloomUpSampledTextures[static_cast<size_t>(i)]->m_pUAV, offsets);
+        DirectX11::CSSetConstantBuffer(0, 1, m_upSampleBuffer.GetAddressOf());
 
-                        DirectX11::CSSetShaderResources(0, 1, &srvPing[dir]);
-                        DirectX11::CSSetUnorderedAccessViews(0, 1, &uavPing[dir], offsets);
+        uint32_t width = DeviceState::g_ClientRect.width >> (i + 1);
+        uint32_t height = DeviceState::g_ClientRect.height >> (i + 1);
+        UINT ugx = (width + 11) / 12;
+        UINT ugy = (height + 7) / 8;
+        DirectX11::Dispatch(ugx, ugy, 1);
 
-                        DirectX11::Dispatch(groupX, groupY, 1);
+        DirectX11::CSSetShaderResources(0, 2, nullSRVs);
+        DirectX11::CSSetUnorderedAccessViews(0, 1, &nullUAV, offsets);
+    }
 
-                        DirectX11::CSSetShaderResources(0, 1, &nullSRV);
-                        DirectX11::CSSetUnorderedAccessViews(0, 1, &nullUAV, offsets);
-                }
-        }
+    // Final composite
+    m_pso->m_pixelShader = m_pBloomCompositePS;
+    m_pso->Apply();
 
-        // Upsample and composite back
-        BloomCompositeParams upsampleComposite{ 1.0f };
-        for (int i = static_cast<int>(BLOOM_MIP_LEVELS) - 1; i > 0; --i)
-        {
-                ID3D11RenderTargetView* rtv = m_bloomMipTextures[static_cast<size_t>(i - 1)]->GetRTV();
-                DirectX11::OMSetRenderTargets(1, &rtv, nullptr);
+    ID3D11RenderTargetView* rtv = m_BloomResult->GetRTV();
+    DirectX11::OMSetRenderTargets(1, &rtv, nullptr);
 
-                DirectX11::PSSetShader(m_pBloomCompositePS->GetShader(), 0, 0);
+    ID3D11ShaderResourceView* pSRVs[]{ m_CopiedTexture->m_pSRV, m_bloomUpSampledTextures[0]->m_pSRV };
+    DirectX11::PSSetShaderResources(0, 2, pSRVs);
+    DirectX11::UpdateBuffer(m_bloomCompositeBuffer.Get(), &m_bloomComposite);
+    DirectX11::PSSetConstantBuffer(0, 1, m_bloomCompositeBuffer.GetAddressOf());
+    DirectX11::Draw(4, 0);
 
-                ID3D11ShaderResourceView* psSRVs[]{ m_bloomMipTextures[static_cast<size_t>(i - 1)]->m_pSRV, m_bloomMipTextures[static_cast<size_t>(i)]->m_pSRV };
-                DirectX11::PSSetShaderResources(0, 2, psSRVs);
+    DirectX11::PSSetShaderResources(0, 2, nullSRVs);
+    DirectX11::UnbindRenderTargets();
 
-                DirectX11::UpdateBuffer(m_bloomCompositeBuffer.Get(), &upsampleComposite);
-                DirectX11::PSSetConstantBuffer(0, 1, m_bloomCompositeBuffer.GetAddressOf());
-
-                DirectX11::Draw(4, 0);
-
-                DirectX11::PSSetShaderResources(0, 1, &nullSRV);
-                DirectX11::UnbindRenderTargets();
-        }
-
-        // Final composite with original image
-        ID3D11RenderTargetView* rtv = m_BloomResult->GetRTV();
-        DirectX11::OMSetRenderTargets(1, &rtv, nullptr);
-
-        DirectX11::PSSetShader(m_pBloomCompositePS->GetShader(), 0, 0);
-
-        ID3D11ShaderResourceView* pSRVs[]{ m_CopiedTexture->m_pSRV, m_bloomMipTextures[0]->m_pSRV };
-        DirectX11::PSSetShaderResources(0, 2, pSRVs);
-
-        DirectX11::UpdateBuffer(m_bloomCompositeBuffer.Get(), &m_bloomComposite);
-        DirectX11::PSSetConstantBuffer(0, 1, m_bloomCompositeBuffer.GetAddressOf());
-
-        DirectX11::Draw(4, 0);
-
-        DirectX11::PSSetShaderResources(0, 1, &nullSRV);
-        DirectX11::UnbindRenderTargets();
-
-        DirectX11::CopyResource(m_CopiedTexture->m_pTexture, m_BloomResult->m_pTexture);
+    DirectX11::CopyResource(m_CopiedTexture->m_pTexture, m_BloomResult->m_pTexture);
 }
 
-void PostProcessingPass::GaussianBlurComputeKernel()
-{
-	float sigma = m_bloomBlur.sigma;
-	float twoSigmaSq = 2.f * sigma * sigma;
-
-	std::vector<float> tempCoefficients(static_cast<size_t>(m_bloomBlur.radius) + 1);
-	float sum = 0.f;
-	for (int i = 0; i <= m_bloomBlur.radius && i <= GAUSSIAN_BLUR_RADIUS; ++i)
-	{
-		tempCoefficients[i] = (1.f / sigma) * std::expf(-static_cast<float>(i * i) / twoSigmaSq);
-		sum += (i == 0) ? tempCoefficients[i] : 2.f * tempCoefficients[i];
-	}
-	float normalizationFactor = 1.f / sum;
-	for (int i = 0; i <= m_bloomBlur.radius && i <= GAUSSIAN_BLUR_RADIUS; ++i)
-	{
-		m_bloomBlur.coefficients[i] = tempCoefficients[i] * normalizationFactor;
-	}
-	for (int i = m_bloomBlur.radius + 1; i <= GAUSSIAN_BLUR_RADIUS; ++i)
-	{
-		m_bloomBlur.coefficients[i] = 0.f;
-	}
-	//float sigma = 5.f;
-	//float sigmaRcp = 1.f / sigma;
-	//float twoSigmaSq = 2 * sigma * sigma;
-
-	//float sum = 0.f;
-	//for (size_t i = 0; i <= GAUSSIAN_BLUR_RADIUS; ++i)
-	//{
-	//	m_bloomBlur.coefficients[i] = (1.f / sigma) * std::expf(-static_cast<float>(i * i) / twoSigmaSq);
-	//	sum += 2 * m_bloomBlur.coefficients[i];
-	//}
-	//sum -= m_bloomBlur.coefficients[0];
-	//float normalizationFactor = 1.f / sum;
-	//for (size_t i = 0; i <= GAUSSIAN_BLUR_RADIUS; ++i)
-	//{
-	//	m_bloomBlur.coefficients[i] *= normalizationFactor;
-	//}
-}
-
-void PostProcessingPass::Resize(uint32_t width, uint32_t height)
+void PostProcessingPass::Resize(uint32_t /*width*/, uint32_t /*height*/)
 {
 }

--- a/RenderEngine/RenderEngine.vcxproj
+++ b/RenderEngine/RenderEngine.vcxproj
@@ -545,11 +545,6 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='GameBuild|x64'">true</ExcludedFromBuild>
     </FxCompile>
-    <FxCompile Include="..\Dynamic_CPP\Assets\Shaders\BloomThresholdDownsample.cs.hlsl">
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='GameBuild|x64'">true</ExcludedFromBuild>
-    </FxCompile>
     <FxCompile Include="..\Dynamic_CPP\Assets\Shaders\BloomDownSample.cs.hlsl">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>

--- a/RenderEngine/RenderEngine.vcxproj.filters
+++ b/RenderEngine/RenderEngine.vcxproj.filters
@@ -876,9 +876,6 @@
     <FxCompile Include="..\Dynamic_CPP\Assets\Shaders\BloomComposite.ps.hlsl">
       <Filter>Shaders\PostProcessShader</Filter>
     </FxCompile>
-    <FxCompile Include="..\Dynamic_CPP\Assets\Shaders\BloomThresholdDownsample.cs.hlsl">
-      <Filter>Shaders\PostProcessShader</Filter>
-    </FxCompile>
     <FxCompile Include="..\Dynamic_CPP\Assets\Shaders\BloomDownSample.cs.hlsl">
       <Filter>Shaders\PostProcessShader</Filter>
     </FxCompile>

--- a/bindings.txt
+++ b/bindings.txt
@@ -8,7 +8,9 @@ Dynamic_CPP/Assets/Shaders\Blit.ps.hlsl: src -> t0
 Dynamic_CPP/Assets/Shaders\BloomComposite.ps.hlsl: tex0 -> t0
 Dynamic_CPP/Assets/Shaders\BloomComposite.ps.hlsl: tex1 -> t1
 Dynamic_CPP/Assets/Shaders\BloomComposite.ps.hlsl: CompositeParams -> b0
-Dynamic_CPP/Assets/Shaders\BloomThresholdDownsample.cs.hlsl: ThresholdParams -> b0
+Dynamic_CPP/Assets/Shaders\BloomExtract.cs.hlsl: BloomBuffer -> b0
+Dynamic_CPP/Assets/Shaders\BloomDownSample.cs.hlsl: BloomDownSampleParams -> b0
+Dynamic_CPP/Assets/Shaders\BloomUpsample.cs.hlsl: BloomUpSampleParams -> b0
 Dynamic_CPP/Assets/Shaders\ColorGrading.ps.hlsl: ColorGradingCBuffer -> b0
 Dynamic_CPP/Assets/Shaders\ColorModule.cs.hlsl: ColorParams -> b0
 Dynamic_CPP/Assets/Shaders\Deferred.ps.hlsl: DeferredCBuffer -> b3


### PR DESCRIPTION
## Summary
- Rewrite PostProcessingPass to use BloomExtract, BloomDownSample, and BloomUpsample compute shaders
- Maintain bloom settings and composite with new constant buffers
- Remove legacy BloomThresholdDownsample shader and update shader bindings

## Testing
- `dotnet build RenderEngine/RenderEngine.vcxproj` *(fails: command not found)*
- `msbuild RenderEngine/RenderEngine.vcxproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c1a8bfa0832db175cf5d975ef489