### PR TITLE
Reflect and edit material constant buffers

### DIFF
--- a/EngineGUIWindow/ImGuiDrawHelperMeshRenderer.cpp
+++ b/EngineGUIWindow/ImGuiDrawHelperMeshRenderer.cpp
@@ -5,6 +5,8 @@
 #include "IconsFontAwesome6.h"
 #include "fa.h"
 #include "ExternUI.h"
+#include <d3d11shader.h>
+#include <cstring>
 #ifndef YAML_CPP_API
 #define YAML_CPP_API __declspec(dllimport)
 #endif /* YAML_CPP_STATIC_DEFINE */
@@ -49,11 +51,11 @@ void ImGuiDrawHelperMeshRenderer(MeshRenderer* meshRenderer)
             ImGui::PopStyleVar(2);
 	}
 
-	if (ImGui::CollapsingHeader("MaterialInfo", ImGuiTreeNodeFlags_DefaultOpen))
-	{
-		const auto& mat_type = Meta::Find("Material");
-		const auto& mat_info_type = Meta::Find("MaterialInfomation");
-		if (nullptr != meshRenderer->m_Material)
+        if (ImGui::CollapsingHeader("MaterialInfo", ImGuiTreeNodeFlags_DefaultOpen))
+        {
+                const auto& mat_type = Meta::Find("Material");
+                const auto& mat_info_type = Meta::Find("MaterialInfomation");
+                if (nullptr != meshRenderer->m_Material)
 		{
 			auto& mat_info = meshRenderer->m_Material->m_materialInfo;
 			ImGui::ColorEdit4("base color", &mat_info.m_baseColor.x);
@@ -73,15 +75,78 @@ void ImGuiDrawHelperMeshRenderer(MeshRenderer* meshRenderer)
 			ImGui::SameLine();
 			ImGui::Button(shaderName.c_str(), ImVec2(200, 0));
 			ImGui::SameLine();
-			if (ImGui::Button(ICON_FA_BOX "##SelectShader"))
-			{
-				ImGui::GetContext("SelectShader").Open();
-			}
-		}
-		else
-		{
-			ImGui::Text("No Material assigned.");
-		}
+                        if (ImGui::Button(ICON_FA_BOX "##SelectShader"))
+                        {
+                                ImGui::GetContext("SelectShader").Open();
+                        }
+
+                        if (meshRenderer->m_Material->m_shaderPSO)
+                        {
+                                if (ImGui::TreeNode("Constants"))
+                                {
+                                        auto& pso = meshRenderer->m_Material->m_shaderPSO;
+                                        for (auto& [cbName, cb] : pso->GetConstantBuffers())
+                                        {
+                                                if (ImGui::TreeNode(cbName.c_str()))
+                                                {
+                                                        auto& storage = meshRenderer->m_Material->m_cbufferValues[cbName];
+                                                        if (storage.size() != cb.size) storage.resize(cb.size);
+                                                        for (auto& var : cb.variables)
+                                                        {
+                                                                uint8_t* data = storage.data() + var.offset;
+                                                                if (var.type == D3D_SVT_FLOAT)
+                                                                {
+                                                                        if (var.size == sizeof(float))
+                                                                        {
+                                                                                float val; std::memcpy(&val, data, sizeof(float));
+                                                                                if (ImGui::DragFloat(var.name.c_str(), &val))
+                                                                                {
+                                                                                        std::memcpy(data, &val, sizeof(float));
+                                                                                        pso->UpdateVariable(cbName, var.name, &val, sizeof(float));
+                                                                                }
+                                                                        }
+                                                                        else if (var.size == sizeof(float) * 4)
+                                                                        {
+                                                                                float vals[4]; std::memcpy(vals, data, sizeof(vals));
+                                                                                if (var.name.find("Color") != std::string::npos)
+                                                                                {
+                                                                                        if (ImGui::ColorEdit4(var.name.c_str(), vals))
+                                                                                        {
+                                                                                                std::memcpy(data, vals, sizeof(vals));
+                                                                                                pso->UpdateVariable(cbName, var.name, vals, sizeof(vals));
+                                                                                        }
+                                                                                }
+                                                                                else if (ImGui::DragFloat4(var.name.c_str(), vals))
+                                                                                {
+                                                                                        std::memcpy(data, vals, sizeof(vals));
+                                                                                        pso->UpdateVariable(cbName, var.name, vals, sizeof(vals));
+                                                                                }
+                                                                        }
+                                                                }
+                                                                else if (var.type == D3D_SVT_INT)
+                                                                {
+                                                                        if (var.size == sizeof(int))
+                                                                        {
+                                                                                int val; std::memcpy(&val, data, sizeof(int));
+                                                                                if (ImGui::DragInt(var.name.c_str(), &val))
+                                                                                {
+                                                                                        std::memcpy(data, &val, sizeof(int));
+                                                                                        pso->UpdateVariable(cbName, var.name, &val, sizeof(int));
+                                                                                }
+                                                                        }
+                                                                }
+                                                        }
+                                                        ImGui::TreePop();
+                                                }
+                                        }
+                                        ImGui::TreePop();
+                                }
+                        }
+                }
+                else
+                {
+                        ImGui::Text("No Material assigned.");
+                }
 		const auto& mat_render_type = Meta::FindEnum("MaterialRenderingMode");
 		for (auto& enumProp : mat_type->properties)
 		{

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 ![스크린샷 2025-06-25 134455](https://github.com/user-attachments/assets/c1db44ad-d6b4-4733-b9cc-2d9e14a09823)
+
+## Material Constant Buffers
+
+Materials now keep CPU-side copies of their shader constant buffer data. The Inspector lists each reflected variable and lets you tweak values in real time. Changes are synchronized to the GPU through `ShaderPSO::UpdateVariable` and serialized with the material asset.
+
+```cpp
+// Update a single float in a constant buffer
+material->m_shaderPSO->UpdateVariable("PerMaterial", "roughness", newValue);
+```

--- a/RenderEngine/Material.cpp
+++ b/RenderEngine/Material.cpp
@@ -1,50 +1,55 @@
 #include "Material.h"
 #include "DataSystem.h"
+#include <cstring>
 
 Material::Material()
 {
 }
 
 Material::Material(const Material& material) :
-	m_name(material.m_name),
-	m_pBaseColor(material.m_pBaseColor),
-	m_pNormal(material.m_pNormal),
-	m_pOccRoughMetal(material.m_pOccRoughMetal),
-	m_AOMap(material.m_AOMap),
-	m_pEmissive(material.m_pEmissive),
-	m_materialInfo(material.m_materialInfo),
-	m_fileGuid(material.m_fileGuid),
-	m_baseColorTexName(material.m_baseColorTexName),
-	m_normalTexName(material.m_normalTexName),
-	m_ORM_TexName(material.m_ORM_TexName),
-	m_AO_TexName(material.m_AO_TexName),
-	m_EmissiveTexName(material.m_EmissiveTexName),
-	m_flowInfo(material.m_flowInfo),
-	m_shaderPSO(material.m_shaderPSO),
-	m_renderingMode(material.m_renderingMode),
-	m_shaderPSOGuid(material.m_shaderPSOGuid)
+        m_name(material.m_name),
+        m_pBaseColor(material.m_pBaseColor),
+        m_pNormal(material.m_pNormal),
+        m_pOccRoughMetal(material.m_pOccRoughMetal),
+        m_AOMap(material.m_AOMap),
+        m_pEmissive(material.m_pEmissive),
+        m_materialInfo(material.m_materialInfo),
+        m_fileGuid(material.m_fileGuid),
+        m_baseColorTexName(material.m_baseColorTexName),
+        m_normalTexName(material.m_normalTexName),
+        m_ORM_TexName(material.m_ORM_TexName),
+        m_AO_TexName(material.m_AO_TexName),
+        m_EmissiveTexName(material.m_EmissiveTexName),
+        m_flowInfo(material.m_flowInfo),
+        m_shaderPSO(material.m_shaderPSO),
+        m_renderingMode(material.m_renderingMode),
+        m_shaderPSOGuid(material.m_shaderPSOGuid),
+        m_cbMeta(material.m_cbMeta),
+        m_cbufferValues(material.m_cbufferValues)
 {
 }
 
 Material::Material(Material&& material) noexcept
 {
-	std::exchange(m_name, material.m_name);
-	std::exchange(m_pBaseColor, material.m_pBaseColor);
-	std::exchange(m_pNormal, material.m_pNormal);
-	std::exchange(m_pOccRoughMetal, material.m_pOccRoughMetal);
-	std::exchange(m_AOMap, material.m_AOMap);
-	std::exchange(m_pEmissive, material.m_pEmissive);
-	std::exchange(m_fileGuid, material.m_fileGuid);
-	std::exchange(m_baseColorTexName, material.m_baseColorTexName);
-	std::exchange(m_normalTexName, material.m_normalTexName);
-	std::exchange(m_ORM_TexName, material.m_ORM_TexName);
-	std::exchange(m_AO_TexName, material.m_AO_TexName);
-	std::exchange(m_EmissiveTexName, material.m_EmissiveTexName);
-	m_materialGuid = std::move(material.m_materialGuid);
-	m_shaderPSOGuid = std::move(material.m_shaderPSOGuid);
-	m_renderingMode = std::move(material.m_renderingMode);
-	m_materialInfo = std::move(material.m_materialInfo);
-	m_flowInfo = std::move(material.m_flowInfo);
+        std::exchange(m_name, material.m_name);
+        std::exchange(m_pBaseColor, material.m_pBaseColor);
+        std::exchange(m_pNormal, material.m_pNormal);
+        std::exchange(m_pOccRoughMetal, material.m_pOccRoughMetal);
+        std::exchange(m_AOMap, material.m_AOMap);
+        std::exchange(m_pEmissive, material.m_pEmissive);
+        std::exchange(m_fileGuid, material.m_fileGuid);
+        std::exchange(m_baseColorTexName, material.m_baseColorTexName);
+        std::exchange(m_normalTexName, material.m_normalTexName);
+        std::exchange(m_ORM_TexName, material.m_ORM_TexName);
+        std::exchange(m_AO_TexName, material.m_AO_TexName);
+        std::exchange(m_EmissiveTexName, material.m_EmissiveTexName);
+        m_materialGuid = std::move(material.m_materialGuid);
+        m_shaderPSOGuid = std::move(material.m_shaderPSOGuid);
+        m_renderingMode = std::move(material.m_renderingMode);
+        m_materialInfo = std::move(material.m_materialInfo);
+        m_flowInfo = std::move(material.m_flowInfo);
+        std::exchange(m_cbMeta, material.m_cbMeta);
+        m_cbufferValues = std::move(material.m_cbufferValues);
 }
 
 Material::~Material()
@@ -213,16 +218,26 @@ Material& Material::SetUVScroll(const Mathf::Vector2& uvScroll)
 
 void Material::SetShaderPSO(std::shared_ptr<ShaderPSO> pso)
 {
-	if (pso)
-	{
-		m_shaderPSO = pso;
-		m_shaderPSOGuid = pso->GetShaderPSOGuid();
-	}
-	else
-	{
-		m_shaderPSO.reset();
-		m_shaderPSOGuid = {};
-	}
+        if (pso)
+        {
+                m_shaderPSO = pso;
+                m_shaderPSOGuid = pso->GetShaderPSOGuid();
+                m_cbMeta = &pso->GetConstantBuffers();
+                m_cbufferValues.clear();
+                for (auto& [name, cb] : pso->GetConstantBuffers())
+                {
+                        auto& storage = m_cbufferValues[name];
+                        storage.resize(cb.size);
+                        std::memcpy(storage.data(), cb.cpuData.data(), cb.size);
+                }
+        }
+        else
+        {
+                m_shaderPSO.reset();
+                m_shaderPSOGuid = {};
+                m_cbMeta = nullptr;
+                m_cbufferValues.clear();
+        }
 }
 
 std::shared_ptr<ShaderPSO> Material::GetShaderPSO() const

--- a/RenderEngine/Material.h
+++ b/RenderEngine/Material.h
@@ -4,6 +4,9 @@
 #include "Texture.h"
 #include "ShaderPSO.h"
 #include "Material.generated.h"
+#include <unordered_map>
+#include <vector>
+#include <cstdint>
 
 enum class MaterialRenderingMode
 {
@@ -79,9 +82,12 @@ public:
     [[Property]]
 	MaterialRenderingMode m_renderingMode{ MaterialRenderingMode::Opaque };
 	HashedGuid m_materialGuid{ make_guid() };
-	std::shared_ptr<ShaderPSO> m_shaderPSO{ nullptr };
-	[[Property]]
-	FileGuid m_shaderPSOGuid{};
+        std::shared_ptr<ShaderPSO> m_shaderPSO{ nullptr };
+        [[Property]]
+        FileGuid m_shaderPSOGuid{};
+        const std::unordered_map<std::string, ShaderPSO::CBEntry>* m_cbMeta{ nullptr };
+        [[Property]]
+        std::unordered_map<std::string, std::vector<uint8_t>> m_cbufferValues{};
 
 };
 


### PR DESCRIPTION
## Summary
- Reflect shader constant buffer variables and track CPU-side data
- Serialize material constant buffer values and expose them in the inspector
- Document and demonstrate per-variable constant buffer editing

## Testing
- `cmake -S . -B build` *(fails: The source directory does not contain CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_68b53027b30c832dafc74c66e101a923