### PR TITLE
Fix DontDestroyOnLoad handling

### DIFF
--- a/ScriptBinder/Scene.cpp
+++ b/ScriptBinder/Scene.cpp
@@ -1053,14 +1053,17 @@ void Scene::DestroyGameObjects()
 		return obj && obj->IsDontDestroyOnLoad();
 	});
 
-	if (eraseSize > 0)
-	{
-		auto& dontDestroyObjects = SceneManagers->GetDontDestroyOnLoadObjects();
-		for (auto& obj : m_SceneObjects)
-		{
-			obj->m_containDontDestroyOnLoad = true;
-		}
-	}
+    if (eraseSize > 0)
+    {
+        auto& dontDestroyObjects = SceneManagers->GetDontDestroyOnLoadObjects();
+        for (auto& obj : dontDestroyObjects)
+        {
+            if (obj)
+            {
+                obj->m_containDontDestroyOnLoad = true;
+            }
+        }
+    }
 
 	std::unordered_set<uint32_t> deletedIndices;
 	for (const auto& obj : m_SceneObjects)


### PR DESCRIPTION
## Summary
- Allow manual destruction of objects marked DontDestroyOnLoad
- Rework SetDontDestroyOnLoad to toggle state and track persistent objects
- Fix Scene cleanup to retain DontDestroyOnLoad objects like Unity

## Testing
- `g++ -std=c++20 -IUtility_Framework -fsyntax-only ScriptBinder/Object.cpp` *(fails: dxgi1_4.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b8eb7d4ae4832dab8e9bcd1cbac439