### PR TITLE
Handle DontDestroyOnLoad object lifecycle

### DIFF
--- a/ScriptBinder/Object.h
+++ b/ScriptBinder/Object.h
@@ -41,8 +41,8 @@ public:
     bool IsEnabled() const { return m_isEnabled; }
 	virtual void SetEnabled(bool able) { m_isEnabled = able; }
 
-	static void Destroy(Object* objPtr);
-    static void SetDontDestroyOnLoad(Object* objPtr, bool setValue = true);
+        static void Destroy(Object* objPtr);
+    static void SetDontDestroyOnLoad(Object* objPtr);
     static Object* Instantiate(const Object* original, std::string_view newName);
 
 public:

--- a/ScriptBinder/Scene.cpp
+++ b/ScriptBinder/Scene.cpp
@@ -412,12 +412,12 @@ void Scene::LateUpdate(float deltaSecond)
 				auto owner = image->GetOwner();
 				if (nullptr == owner) continue;
 
-				auto scene = owner->GetScene();
+                                auto scene = owner->GetScene();
 
-				if (scene && scene == this)
-				{
-					data->PushUIRenderData(image->GetInstanceID());
-				}
+                                if (scene && (scene == this || owner->IsDontDestroyOnLoad()))
+                                {
+                                        data->PushUIRenderData(image->GetInstanceID());
+                                }
 			}
 		});
 
@@ -430,12 +430,12 @@ void Scene::LateUpdate(float deltaSecond)
 				auto owner = text->GetOwner();
 				if (nullptr == owner) continue;
 
-				auto scene = owner->GetScene();
+                                auto scene = owner->GetScene();
 
-				if (scene && scene == this)
-				{
-					data->PushUIRenderData(text->GetInstanceID());
-				}
+                                if (scene && (scene == this || owner->IsDontDestroyOnLoad()))
+                                {
+                                        data->PushUIRenderData(text->GetInstanceID());
+                                }
 			}
 		});
 
@@ -1048,27 +1048,15 @@ void Scene::UnCollectColliderComponent(TerrainColliderComponent* ptr)
 
 void Scene::DestroyGameObjects()
 {
-	size_t eraseSize = std::erase_if(m_SceneObjects, [](const auto& obj)
-	{
-		return obj && obj->IsDontDestroyOnLoad();
-	});
-
-    if (eraseSize > 0)
-    {
-        auto& dontDestroyObjects = SceneManagers->GetDontDestroyOnLoadObjects();
-        for (auto& obj : dontDestroyObjects)
+        std::erase_if(m_SceneObjects, [](const auto& obj)
         {
-            if (obj)
-            {
-                obj->m_containDontDestroyOnLoad = true;
-            }
-        }
-    }
+                return obj && obj->IsDontDestroyOnLoad();
+        });
 
-	std::unordered_set<uint32_t> deletedIndices;
-	for (const auto& obj : m_SceneObjects)
-	{
-		if (obj && obj->IsDestroyMark())
+        std::unordered_set<uint32_t> deletedIndices;
+        for (const auto& obj : m_SceneObjects)
+        {
+                if (obj && obj->IsDestroyMark())
 			deletedIndices.insert(obj->m_index);
 	}
 


### PR DESCRIPTION
## Summary
- Keep UI components from DontDestroyOnLoad objects rendering across scenes
- Clean up DontDestroyOnLoad objects at end of frame and engine shutdown
- Rework Object::SetDontDestroyOnLoad to promote entire hierarchies to persistent scope

## Testing
- `g++ -std=c++20 -I. -IScriptBinder -IUtility_Framework -IRenderEngine -IEngineEntry -c ScriptBinder/Object.cpp` *(fails: dxgi1_4.h: No such file or directory)*
- `g++ -std=c++20 -I. -IScriptBinder -IUtility_Framework -IRenderEngine -IEngineEntry -c ScriptBinder/SceneManager.cpp` *(fails: dxgi1_4.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ef0802a0832d804d4f49eb84b7d0