### PR TITLE
Refine DDOL handling and root indexing

### DIFF
--- a/ScriptBinder/Scene.cpp
+++ b/ScriptBinder/Scene.cpp
@@ -597,7 +597,11 @@ void Scene::LateUpdate(float deltaSecond)
 
                                 auto scene = owner->GetScene();
 
-                                if (scene && (scene == this || owner->IsDontDestroyOnLoad()))
+                                // (G) UI 중복 렌더 가드:
+                                //  - 같은 씬이면 렌더
+                                //  - DDOL이면 "활성 씬 소속"인 경우에만 렌더
+                                if (scene && (scene == this ||
+                                    (owner->IsDontDestroyOnLoad() && scene == SceneManagers->GetActiveScene())))
                                 {
                                         data->PushUIRenderData(image->GetInstanceID());
                                 }
@@ -615,7 +619,8 @@ void Scene::LateUpdate(float deltaSecond)
 
                                 auto scene = owner->GetScene();
 
-                                if (scene && (scene == this || owner->IsDontDestroyOnLoad()))
+                                if (scene && (scene == this ||
+                                    (owner->IsDontDestroyOnLoad() && scene == SceneManagers->GetActiveScene())))
                                 {
                                         data->PushUIRenderData(text->GetInstanceID());
                                 }

--- a/ScriptBinder/SceneManager.cpp
+++ b/ScriptBinder/SceneManager.cpp
@@ -609,6 +609,25 @@ void SceneManager::RebindEventDontDestroyOnLoadObjects(Scene* scene)
     auto remap = scene->AttachExistingGameObjectHierarchy(roots);
     (void)remap;
 
+    // (D) 루트 규약 통일: INVALID_INDEX(= -1)일 때 부모 없음으로 설정
+    for (auto& gameObject : roots)
+    {
+        if (!gameObject) continue;
+        gameObject->m_transform.SetParentID(GameObject::IsValidIndex(gameObject->m_parentIndex)
+            ? gameObject->m_parentIndex
+            : GameObject::INVALID_INDEX);
+
+        // (D) 루트 판정: 0이 아닌 INVALID_INDEX를 루트로 취급
+        if (gameObject->m_parentIndex == GameObject::INVALID_INDEX)
+        {
+            auto& rootChildren = scene->m_SceneObjects[0]->m_childrenIndices;
+            if (std::find(rootChildren.begin(), rootChildren.end(), gameObject->m_index) == rootChildren.end())
+            {
+                rootChildren.push_back(gameObject->m_index);
+            }
+        }
+    }
+
     // 컴포넌트 이벤트 재등록
     for (auto& obj : m_dontDestroyOnLoadObjects)
     {


### PR DESCRIPTION
## Summary
- ensure DontDestroyOnLoad objects unregister from original scene collections
- unify root indexing when rebinding DDOL objects
- avoid double UI rendering for DDOL objects only active in current scene

## Testing
- `g++ -std=c++20 -fsyntax-only ScriptBinder/Object.cpp ScriptBinder/Scene.cpp ScriptBinder/SceneManager.cpp -I ScriptBinder -I . -I Utility_Framework -I Physics` *(fails: dxgi1_4.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b92eb2a390832d95ae0783454ae5c0