### PR TITLE
Handle canvas cleanup by pointer to avoid scene name collisions

### DIFF
--- a/ScriptBinder/Canvas.cpp
+++ b/ScriptBinder/Canvas.cpp
@@ -21,7 +21,7 @@ void Canvas::OnDestroy()
 		{
 			UIManagers->CurCanvas.reset();
 		}
-		UIManagers->DeleteCanvas(m_pOwner->ToString());
+		UIManagers->DeleteCanvas(m_pOwner->shared_from_this());
 	}
 }
 
@@ -48,7 +48,7 @@ void Canvas::AddUIObject(std::shared_ptr<GameObject> obj)
 		btn->m_ownerCanvasName = m_pOwner->m_name.ToString();
 	}
 	UIObjs.push_back(obj);
-	//¸ÇÃ³À½ Ãß°¡µÇ´Â UI¸¦ ¼±ÅÃµÈ UI·Î ÁöÁ¤
+	//ë§¨ì²˜ìŒ ì¶”ê°€ë˜ëŠ” UIë¥¼ ì„ íƒëœ UIë¡œ ì§€ì •
 	if (SelectUI.expired())
 	{
 		SelectUI = obj;
@@ -64,7 +64,7 @@ void Canvas::Update(float tick)
 		PreCanvasOrder = CanvasOrder;
 	}
 
-	////ÀÌ ºÎºĞ UI Manager ¿¡¼­ ÅëÇÕÀ¸·Î Ã³¸®ÇÏÀÚ
+	////ì´ ë¶€ë¶„ UI Manager ì—ì„œ í†µí•©ìœ¼ë¡œ ì²˜ë¦¬í•˜ì
 	std::erase_if(UIObjs, [](const std::weak_ptr<GameObject>& obj) 
 		{ return obj.expired() || (obj.lock() && obj.lock()->IsDestroyMark()); });
 }

--- a/ScriptBinder/UIManager.cpp
+++ b/ScriptBinder/UIManager.cpp
@@ -2,12 +2,13 @@
 #include "SceneManager.h"
 #include "Scene.h"
 #include "Canvas.h"
-#include "ImageComponent.h"	
+#include "ImageComponent.h"
 #include "UIButton.h"
 #include "InputManager.h"
 #include "TextComponent.h"
 #include "RectTransformComponent.h"
 #include "../RenderEngine/DeviceState.h"
+#include <algorithm>
 
 std::shared_ptr<GameObject> UIManager::MakeCanvas(std::string_view name)
 {
@@ -279,34 +280,38 @@ std::shared_ptr<GameObject> UIManager::MakeText(std::string_view name, file::pat
 	return newText;
 }
 
-void UIManager::DeleteCanvas(std::string canvasName)
+void UIManager::DeleteCanvas(const std::shared_ptr<GameObject>& canvas)
 {
-	auto it = std::find_if(Canvases.begin(), Canvases.end(), [&](const std::weak_ptr<GameObject>& canvas) 
-	{
-		auto c = canvas.lock();
-		return c && c->ToString() == canvasName;
-	});
+        if (!canvas) return;
 
-	if (it != Canvases.end())
-	{
-		auto curCanvasObj = (*it).lock();
-		auto canvasCom = curCanvasObj->GetComponent<Canvas>();
-		for (auto& uiObj : canvasCom->UIObjs)
-		{
-			auto uiObjPtr = uiObj.lock();
-			if (uiObjPtr)
-				uiObjPtr->Destroy();
-		}
-		canvasCom->UIObjs.clear();
+        auto it = std::find_if(Canvases.begin(), Canvases.end(), [&](const std::weak_ptr<GameObject>& c)
+        {
+                return !c.expired() && c.lock() == canvas;
+        });
 
-		std::erase_if(Canvases, [&](const std::weak_ptr<GameObject>& canvas)
-			{
-				auto c = canvas.lock();
-				return !c || c->ToString() == canvasName;
-			});
+        if (it != Canvases.end())
+        {
+                auto canvasCom = canvas->GetComponent<Canvas>();
+                for (auto& uiObj : canvasCom->UIObjs)
+                {
+                        if (auto uiObjPtr = uiObj.lock())
+                                uiObjPtr->Destroy();
+                }
+                canvasCom->UIObjs.clear();
 
-		curCanvasObj->Destroy();
-	}
+                std::erase_if(Canvases, [&](const std::weak_ptr<GameObject>& c)
+                        {
+                                return c.expired() || c.lock() == canvas;
+                        });
+
+                std::erase_if(CanvasMap, [&](auto& pair)
+                        {
+                                auto sp = pair.second.lock();
+                                return !sp || sp == canvas;
+                        });
+
+                canvas->Destroy();
+        }
 }
 
 void UIManager::CheckInput()

--- a/ScriptBinder/UIManager.h
+++ b/ScriptBinder/UIManager.h
@@ -14,7 +14,7 @@ public:
 	Core::Delegate<void, Mathf::Vector2> m_clickEvent;
 	std::shared_ptr<GameObject> MakeCanvas(std::string_view name = "Canvas");
 	void AddCanvas(std::shared_ptr<GameObject> canvas);
-	//¿ÀºêÁ§ÀÌ¸§ /¾µ Á¤º¸ / ¾î´ÀÄµ¹ö½º ±âº»0
+	void DeleteCanvas(const std::shared_ptr<GameObject>& canvas);
 	std::shared_ptr<GameObject> MakeImage(std::string_view name, const std::shared_ptr<Texture>& texture,GameObject* canvas = nullptr,Mathf::Vector2 Pos = { 960,540 });
 	std::shared_ptr<GameObject> MakeImage(std::string_view name, const std::shared_ptr<Texture>& texture, std::string_view canvasname, Mathf::Vector2 Pos = { 960,540 });
 	std::shared_ptr<GameObject> MakeButton(std::string_view name, const std::shared_ptr<Texture>& texture, std::function<void()> clickfun, Mathf::Vector2 Pos = { 960,540 },GameObject* canvas = nullptr);
@@ -38,13 +38,13 @@ public:
 
 
 public:
-	//Äµ¹ö½º ÄÄÆ÷³ÍÆ®°¡ µé¾îÀÖ´Â°Í¸¸ µé¾î°¡°Ô²û
+	//ìº”ë²„ìŠ¤ ì»´í¬ë„ŒíŠ¸ê°€ ë“¤ì–´ìˆëŠ”ê²ƒë§Œ ë“¤ì–´ê°€ê²Œë”
 	std::vector<std::weak_ptr<GameObject>>	Canvases;
 	std::unordered_map<std::string, std::weak_ptr<GameObject>> CanvasMap;
 	std::vector<ImageComponent*>			Images;
 	std::vector<TextComponent*>				Texts;
-	//ÀÌÁ¤ Äµ¹ö½º
-	//ÇöÀç »óÈ£ÀÛ¿ëÇÒ UI
+	//ì´ì • ìº”ë²„ìŠ¤
+	//í˜„ì¬ ìƒí˜¸ì‘ìš©í•  UI
 	std::weak_ptr<GameObject> CurCanvas;
 	GameObject* SelectUI = nullptr;
 
@@ -71,7 +71,7 @@ interface ICollision2D
 	virtual void CheckClick(Mathf::Vector2 _mousePos) = 0;
 	Core::DelegateHandle m_clickEventHandle{};
 };
-//btn clilc -> colliderµé È®ÀÎ -> °¡Àå¸Â´Â  uiÇÔ¼ö ½ÇÇà
-//ÇöÀç ¼±ÅÃ canvas -> ÇöÀç ¼±ÅÃ°¡´ÉÇÑ  uiÁß ÇÏ³ª °í¸£°Ô²û
-//canvas¾ø´Â ´ÜÀÏÀº?
+//btn clilc -> colliderë“¤ í™•ì¸ -> ê°€ì¥ë§ëŠ”  uií•¨ìˆ˜ ì‹¤í–‰
+//í˜„ì¬ ì„ íƒ canvas -> í˜„ì¬ ì„ íƒê°€ëŠ¥í•œ  uiì¤‘ í•˜ë‚˜ ê³ ë¥´ê²Œë”
+//canvasì—†ëŠ” ë‹¨ì¼ì€?
 


### PR DESCRIPTION
## Summary
- Remove canvases by pointer in UIManager to prevent cross-scene name collisions and clean CanvasMap
- Update Canvas::OnDestroy to pass its shared pointer to UIManager for deletion

## Testing
- `g++ -std=c++20 -fsyntax-only ScriptBinder/UIManager.cpp ScriptBinder/Canvas.cpp` *(fails: dxgi1_4.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c23e0b0468832d8479a60afb75fba8