### PR TITLE
feat: enable custom sprite shaders

### DIFF
--- a/RenderEngine/MeshRendererProxy.h
+++ b/RenderEngine/MeshRendererProxy.h
@@ -28,7 +28,7 @@ class FoliageComponent;
 class DecalComponent;
 class SpriteRenderer;
 class Texture;
-class PrimitiveRenderProxy //¾Æ °¢ Å¸ÀÔº°·Î ºĞ¸®ÇÏ°í ½Í´Ù...
+class PrimitiveRenderProxy //ì•„ ê° íƒ€ì…ë³„ë¡œ ë¶„ë¦¬í•˜ê³  ì‹¶ë‹¤...
 {
 public:
 	struct ProxyFilter
@@ -126,6 +126,8 @@ public:
 	//sprite type
 	std::shared_ptr<Mesh>           m_quadMesh{ nullptr };
 	Texture*						m_spriteTexture{ nullptr };
+        std::string m_vertexShaderName{ "VertexShader" };
+        std::string m_pixelShaderName{ "Sprite" };
 
 private:
 	bool							m_isNeedUpdateCulling{ false };

--- a/RenderEngine/ProxyCommand.cpp
+++ b/RenderEngine/ProxyCommand.cpp
@@ -124,10 +124,12 @@ ProxyCommand::ProxyCommand(SpriteRenderer* pComponent)
 	bool isEnabled = owner->IsEnabled();
 	Mathf::xMatrix worldMatrix = owner->m_transform.GetWorldMatrix();
 	Mathf::Vector3 worldPosition = owner->m_transform.GetWorldPosition();
+        std::string vertexShaderName = componentPtr->GetVertexShaderName();
+        std::string pixelShaderName = componentPtr->GetPixelShaderName();
 	if (!owner || owner->IsDestroyMark() || pComponent->IsDestroyMark()) return;
 	auto& proxyObject = renderScene->m_proxyMap[m_proxyGUID];
 	if (!proxyObject) return;
-	Texture* originTexture = pComponent->m_Sprite;
+	Texture* originTexture = pComponent->GetSprite().get();
 	if (!originTexture)
 	{
 		m_updateFunction = [=]
@@ -144,7 +146,9 @@ ProxyCommand::ProxyCommand(SpriteRenderer* pComponent)
 		proxyObject->m_isStatic = isStatic;
 		proxyObject->m_isEnableShadow = isEnabled;
 		proxyObject->m_spriteTexture = originTexture;
-	};
+                proxyObject->m_vertexShaderName = vertexShaderName;
+                proxyObject->m_pixelShaderName = pixelShaderName;
+        };
 }
 
 
@@ -282,7 +286,7 @@ ProxyCommand::ProxyCommand(SpriteSheetComponent* pComponent) :
 	{
 		if (auto proxyObject = weakProxyObject.lock())
 		{
-			// texture´Â imutableÃ³·³ °ü¸®(ÇÑ¹ø ¼³Á¤µÇ¸é ÀÌÈÄ º¯°æµÇÁö ¾ÊÀ½)
+			// textureëŠ” imutableì²˜ëŸ¼ ê´€ë¦¬(í•œë²ˆ ì„¤ì •ë˜ë©´ ì´í›„ ë³€ê²½ë˜ì§€ ì•ŠìŒ)
 			UIRenderProxy::SpriteSheetData data{};
 			data.origin = origin;
 			data.position = position;

--- a/RenderEngine/RenderPassData.cpp
+++ b/RenderEngine/RenderPassData.cpp
@@ -131,7 +131,7 @@ void RenderPassData::Initalize(uint32 index)
 
 	}
 
-	//¾È¿¡¼­ ¹è¿­Àº 3À¸·Î °íÁ¤Áß ÇÊ¿äÇÏ¸é ¼öÁ¤
+	//ì•ˆì—ì„œ ë°°ì—´ì€ 3ìœ¼ë¡œ ê³ ì •ì¤‘ í•„ìš”í•˜ë©´ ìˆ˜ì •
 	shadowMapTexture->CreateSRV(DXGI_FORMAT_R32_FLOAT, D3D11_SRV_DIMENSION_TEXTURE2DARRAY);
 	shadowMapTexture->m_textureType = TextureType::ImageTexture;
 	m_shadowMapTexture.swap(shadowMapTexture);
@@ -240,6 +240,7 @@ void RenderPassData::ClearRenderQueue()
 	m_foliageQueue.clear();
 	m_UIRenderQueue.clear();
 	m_decalQueue.clear();
+        m_spriteRenderQueue.clear();
 }
 
 void RenderPassData::PushShadowRenderQueue(PrimitiveRenderProxy* proxy)

--- a/RenderEngine/SpritePass.h
+++ b/RenderEngine/SpritePass.h
@@ -17,7 +17,6 @@ public:
 	void Resize(uint32_t width, uint32_t height) override;
 
 private:
-	bool m_isGizmoRendering{ false };
-	std::unique_ptr<Mesh> m_QuadMesh{};
-	ComPtr<ID3D11DepthStencilState> m_NoWriteDepthStencilState{};
+        bool m_isGizmoRendering{ false };
+        ComPtr<ID3D11DepthStencilState> m_NoWriteDepthStencilState{};
 };

--- a/ScriptBinder/SpriteRenderer.h
+++ b/ScriptBinder/SpriteRenderer.h
@@ -20,6 +20,10 @@ public:
    void DeserializeSprite(const std::shared_ptr<Texture>& ptr);
 
    const std::shared_ptr<Texture>& GetSprite() const { return m_Sprite; }
+   void SetVertexShaderName(const std::string& name) { m_VertexShaderName = name; }
+   void SetPixelShaderName(const std::string& name) { m_PixelShaderName = name; }
+   const std::string& GetVertexShaderName() const { return m_VertexShaderName; }
+   const std::string& GetPixelShaderName() const { return m_PixelShaderName; }
 
 private:
     [[Property]]


### PR DESCRIPTION
## Summary
- support custom vertex and pixel shaders in SpriteRenderer
- route SpritePass rendering through PrimitiveRenderProxy using deferred contexts
- maintain sprite proxy queue in render data

## Testing
- `g++ -std=c++20 -c RenderEngine/SpritePass.cpp` *(fails: Core.Minimal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b8ea1054832d96632515e099f7d3