### PR TITLE
Clamp TextComponent rendering to parent rect

### DIFF
--- a/ScriptBinder/TextComponent.cpp
+++ b/ScriptBinder/TextComponent.cpp
@@ -5,6 +5,7 @@
 #include "RenderScene.h"
 #include "UIManager.h"
 #include "RectTransformComponent.h"
+#include "GameObject.h"
 
 TextComponent::TextComponent()
 {
@@ -32,8 +33,21 @@ void TextComponent::Update(float tick)
             const auto& worldRect = rect->GetWorldRect();
             pos = { worldRect.x, worldRect.y };
             stretchSize = { worldRect.w, worldRect.h };
-            isStretchX = rect->GetAnchorMin().x != rect->GetAnchorMax().x;
-            isStretchY = rect->GetAnchorMin().y != rect->GetAnchorMax().y;
+
+            if (GameObject::IsValidIndex(m_pOwner->m_parentIndex))
+            {
+                    if (auto* parent = GameObject::FindIndex(m_pOwner->m_parentIndex))
+                    {
+                            if (auto* parentRect = parent->GetComponent<RectTransformComponent>())
+                            {
+                                    const auto& pRect = parentRect->GetWorldRect();
+                                    stretchSize = { pRect.w, pRect.h };
+                            }
+                    }
+            }
+
+            isStretchX = true;
+            isStretchY = true;
     }
     //pos += relpos;
 

--- a/ScriptBinder/TextComponent.h
+++ b/ScriptBinder/TextComponent.h
@@ -48,7 +48,7 @@ private:
         [[Property]]
         float fontSize{ 1.f };
 
-        // Calculated in Update: maximum render area from RectTransform's stretch
+        // Calculated in Update: maximum render area from parent RectTransform
         Mathf::Vector2 stretchSize{ 0.f, 0.f };
         bool isStretchX{ false };
         bool isStretchY{ false };


### PR DESCRIPTION
## Summary
- Ensure TextComponent respects its parent's RectTransform by scaling text to fit within the parent bounds
- Clarify stretch limit documentation to reflect parent-based sizing

## Testing
- `g++ -std=c++20 -c ScriptBinder/TextComponent.cpp -I. -o /tmp/textcomponent.o` *(fails: dxgi1_4.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c3e2632d24832db9cb1f3f83be589e