### PR TITLE
Allow manual Rect override for TextComponent

### DIFF
--- a/ScriptBinder/TextComponent.cpp
+++ b/ScriptBinder/TextComponent.cpp
@@ -28,11 +28,18 @@ void TextComponent::Awake()
 
 void TextComponent::Update(float tick)
 {
-    if (auto* rect = m_pOwner->GetComponent<RectTransformComponent>())
+    if (useManualRect)
+    {
+            pos = { manualRect.x, manualRect.y };
+            stretchSize = { manualRect.width, manualRect.height };
+            isStretchX = true;
+            isStretchY = true;
+    }
+    else if (auto* rect = m_pOwner->GetComponent<RectTransformComponent>())
     {
             const auto& worldRect = rect->GetWorldRect();
             pos = { worldRect.x, worldRect.y };
-            stretchSize = { worldRect.w, worldRect.h };
+            stretchSize = { worldRect.width, worldRect.height };
 
             if (GameObject::IsValidIndex(m_pOwner->m_parentIndex))
             {
@@ -41,7 +48,7 @@ void TextComponent::Update(float tick)
                             if (auto* parentRect = parent->GetComponent<RectTransformComponent>())
                             {
                                     const auto& pRect = parentRect->GetWorldRect();
-                                    stretchSize = { pRect.w, pRect.h };
+                                    stretchSize = { pRect.width, pRect.height };
                             }
                     }
             }

--- a/ScriptBinder/TextComponent.h
+++ b/ScriptBinder/TextComponent.h
@@ -48,6 +48,12 @@ private:
         [[Property]]
         float fontSize{ 1.f };
 
+        // When true, message bounds are taken from manualRect instead of the parent's RectTransform
+        [[Property]]
+        bool useManualRect{ false };
+        [[Property]]
+        Mathf::Rect manualRect{};
+
         // Calculated in Update: maximum render area from parent RectTransform
         Mathf::Vector2 stretchSize{ 0.f, 0.f };
         bool isStretchX{ false };


### PR DESCRIPTION
## Summary
- Add properties enabling manual Rect bounds on TextComponent
- Use manual rect in Update when enabled and reference width/height fields

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3e9f97c18832d9ba4242ef324441e