### PR TITLE
Support custom PSO for SpriteRenderer

### DIFF
--- a/RenderEngine/MeshRendererProxy.cpp
+++ b/RenderEngine/MeshRendererProxy.cpp
@@ -11,6 +11,7 @@
 #include "DecalComponent.h"
 #include "Texture.h"
 #include "SpriteRenderer.h"
+#include "ShaderSystem.h"
 
 //constexpr size_t TRANSFORM_SIZE = sizeof(Mathf::xMatrix) * MAX_BONES;
 
@@ -89,9 +90,16 @@ PrimitiveRenderProxy::PrimitiveRenderProxy(DecalComponent* component) :
 
 PrimitiveRenderProxy::PrimitiveRenderProxy(SpriteRenderer* component) :
     m_spriteTexture(component->GetSprite().get()),
-    m_vertexShaderName(component->GetVertexShaderName()),
-    m_pixelShaderName(component->GetPixelShaderName())
+    m_customPSOName(component->GetCustomPSOName())
 {
+    if (!m_customPSOName.empty())
+    {
+        auto it = ShaderSystem->ShaderAssets.find(m_customPSOName);
+        if (it != ShaderSystem->ShaderAssets.end())
+        {
+            m_customPSO = it->second;
+        }
+    }
     m_quadMesh = std::make_shared<Mesh>(
         component->GetOwner()->m_name.ToString(),
         PrimitiveCreator::QuadVertices(),
@@ -146,9 +154,13 @@ PrimitiveRenderProxy::PrimitiveRenderProxy(const PrimitiveRenderProxy& other) :
     m_diffuseTexture(other.m_diffuseTexture),
     m_normalTexture(other.m_normalTexture),
     m_occluroughmetalTexture(other.m_occluroughmetalTexture),
-	m_sliceX(other.m_sliceX),
-	m_sliceY(other.m_sliceY),
-	m_sliceNum(other.m_sliceNum)
+        m_sliceX(other.m_sliceX),
+        m_sliceY(other.m_sliceY),
+        m_sliceNum(other.m_sliceNum),
+        m_quadMesh(other.m_quadMesh),
+        m_spriteTexture(other.m_spriteTexture),
+        m_customPSOName(other.m_customPSOName),
+        m_customPSO(other.m_customPSO)
 {
 }
 
@@ -178,9 +190,13 @@ PrimitiveRenderProxy::PrimitiveRenderProxy(PrimitiveRenderProxy&& other) noexcep
     m_diffuseTexture(std::exchange(other.m_diffuseTexture, nullptr)),
     m_normalTexture(std::exchange(other.m_normalTexture, nullptr)),
     m_occluroughmetalTexture(std::exchange(other.m_occluroughmetalTexture, nullptr)),
-	m_sliceX(other.m_sliceX),
-	m_sliceY(other.m_sliceY),
-	m_sliceNum(other.m_sliceNum)
+        m_sliceX(other.m_sliceX),
+        m_sliceY(other.m_sliceY),
+        m_sliceNum(other.m_sliceNum),
+        m_quadMesh(std::move(other.m_quadMesh)),
+        m_spriteTexture(std::exchange(other.m_spriteTexture, nullptr)),
+        m_customPSOName(std::move(other.m_customPSOName)),
+        m_customPSO(std::move(other.m_customPSO))
 {
 }
 

--- a/RenderEngine/MeshRendererProxy.h
+++ b/RenderEngine/MeshRendererProxy.h
@@ -28,6 +28,7 @@ class FoliageComponent;
 class DecalComponent;
 class SpriteRenderer;
 class Texture;
+class ShaderPSO;
 class PrimitiveRenderProxy //아 각 타입별로 분리하고 싶다...
 {
 public:
@@ -126,8 +127,8 @@ public:
 	//sprite type
 	std::shared_ptr<Mesh>           m_quadMesh{ nullptr };
 	Texture*						m_spriteTexture{ nullptr };
-        std::string m_vertexShaderName{ "VertexShader" };
-        std::string m_pixelShaderName{ "Sprite" };
+        std::string m_customPSOName{};
+        std::shared_ptr<ShaderPSO>      m_customPSO{ nullptr };
 
 private:
 	bool							m_isNeedUpdateCulling{ false };

--- a/RenderEngine/ProxyCommand.cpp
+++ b/RenderEngine/ProxyCommand.cpp
@@ -10,6 +10,7 @@
 #include "Material.h"
 #include "SpriteRenderer.h"
 #include "DecalComponent.h"
+#include "ShaderSystem.h"
 
 constexpr size_t TRANSFORM_SIZE = sizeof(Mathf::xMatrix) * MAX_BONES;
 
@@ -124,8 +125,7 @@ ProxyCommand::ProxyCommand(SpriteRenderer* pComponent)
 	bool isEnabled = owner->IsEnabled();
 	Mathf::xMatrix worldMatrix = owner->m_transform.GetWorldMatrix();
 	Mathf::Vector3 worldPosition = owner->m_transform.GetWorldPosition();
-        std::string vertexShaderName = componentPtr->GetVertexShaderName();
-        std::string pixelShaderName = componentPtr->GetPixelShaderName();
+        std::string customPSOName = componentPtr->GetCustomPSOName();
 	if (!owner || owner->IsDestroyMark() || pComponent->IsDestroyMark()) return;
 	auto& proxyObject = renderScene->m_proxyMap[m_proxyGUID];
 	if (!proxyObject) return;
@@ -145,9 +145,17 @@ ProxyCommand::ProxyCommand(SpriteRenderer* pComponent)
 		proxyObject->m_worldPosition = worldPosition;
 		proxyObject->m_isStatic = isStatic;
 		proxyObject->m_isEnableShadow = isEnabled;
-		proxyObject->m_spriteTexture = originTexture;
-                proxyObject->m_vertexShaderName = vertexShaderName;
-                proxyObject->m_pixelShaderName = pixelShaderName;
+                proxyObject->m_spriteTexture = originTexture;
+                proxyObject->m_customPSOName = customPSOName;
+                if (!customPSOName.empty())
+                {
+                        auto it = ShaderSystem->ShaderAssets.find(customPSOName);
+                        proxyObject->m_customPSO = (it != ShaderSystem->ShaderAssets.end()) ? it->second : nullptr;
+                }
+                else
+                {
+                        proxyObject->m_customPSO = nullptr;
+                }
         };
 }
 

--- a/RenderEngine/SpritePass.cpp
+++ b/RenderEngine/SpritePass.cpp
@@ -88,12 +88,14 @@ void SpritePass::CreateRenderCommandList(ID3D11DeviceContext* deferredContext, R
     for (auto& proxy : renderData->m_spriteRenderQueue)
     {
         if (!proxy || !proxy->m_quadMesh || !proxy->m_spriteTexture) continue;
-        if (ShaderSystem->VertexShaders.find(proxy->m_vertexShaderName) == ShaderSystem->VertexShaders.end()) continue;
-        if (ShaderSystem->PixelShaders.find(proxy->m_pixelShaderName) == ShaderSystem->PixelShaders.end()) continue;
-
-        m_pso->m_vertexShader = &ShaderSystem->VertexShaders[proxy->m_vertexShaderName];
-        m_pso->m_pixelShader = &ShaderSystem->PixelShaders[proxy->m_pixelShaderName];
-        m_pso->Apply(deferredPtr);
+        if (proxy->m_customPSO)
+        {
+            proxy->m_customPSO->Apply(deferredPtr);
+        }
+        else
+        {
+            m_pso->Apply(deferredPtr);
+        }
 
         scene.UpdateModel(proxy->m_worldMatrix, deferredPtr);
         ID3D11ShaderResourceView* srv = proxy->m_spriteTexture->m_pSRV;

--- a/ScriptBinder/SpriteRenderer.generated.h
+++ b/ScriptBinder/SpriteRenderer.generated.h
@@ -4,11 +4,10 @@
 ReflectionFieldInheritance(SpriteRenderer, Component) \
 { \
 	PropertyField \
-	({ \
-		meta_property(m_SpritePath) \
-		meta_property(m_VertexShaderName) \
-		meta_property(m_PixelShaderName) \
-		meta_property(m_orderInLayer) \
-	}); \
+        ({ \
+                meta_property(m_SpritePath) \
+                meta_property(m_CustomPSOName) \
+                meta_property(m_orderInLayer) \
+        }); \
 	FieldEnd(SpriteRenderer, PropertyOnlyInheritance) \
 };

--- a/ScriptBinder/SpriteRenderer.h
+++ b/ScriptBinder/SpriteRenderer.h
@@ -20,18 +20,14 @@ public:
    void DeserializeSprite(const std::shared_ptr<Texture>& ptr);
 
    const std::shared_ptr<Texture>& GetSprite() const { return m_Sprite; }
-   void SetVertexShaderName(const std::string& name) { m_VertexShaderName = name; }
-   void SetPixelShaderName(const std::string& name) { m_PixelShaderName = name; }
-   const std::string& GetVertexShaderName() const { return m_VertexShaderName; }
-   const std::string& GetPixelShaderName() const { return m_PixelShaderName; }
+   void SetCustomPSOName(const std::string& name) { m_CustomPSOName = name; }
+   const std::string& GetCustomPSOName() const { return m_CustomPSOName; }
 
 private:
     [[Property]]
     std::string m_SpritePath{};
     [[Property]]
-	std::string m_VertexShaderName{ "VertexShader" };
-    [[Property]]
-	std::string m_PixelShaderName{ "Sprite" };
+    std::string m_CustomPSOName{};
     [[Property]]
     int m_orderInLayer{ 0 };
 


### PR DESCRIPTION
## Summary
- allow SpriteRenderer to serialize a custom PSO name
- load custom PSOs from ShaderSystem in render proxy
- apply custom PSO when rendering sprites
- remove per-sprite vertex/pixel shader selection to rely solely on ShaderPSO

## Testing
- `msbuild GameBuild.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c37717293c832d807cff204637d7c3