### PR TITLE
feat: add cylindrical billboard support

### DIFF
--- a/BillboardType.h
+++ b/BillboardType.h
@@ -1,0 +1,8 @@
+#pragma once
+
+enum class BillboardType {
+    None = 0,
+    Spherical = 1,
+    Cylindrical = 2
+};
+

--- a/RenderEngine/MeshRendererProxy.cpp
+++ b/RenderEngine/MeshRendererProxy.cpp
@@ -90,7 +90,9 @@ PrimitiveRenderProxy::PrimitiveRenderProxy(DecalComponent* component) :
 
 PrimitiveRenderProxy::PrimitiveRenderProxy(SpriteRenderer* component) :
     m_spriteTexture(component->GetSprite().get()),
-    m_customPSOName(component->GetCustomPSOName())
+    m_customPSOName(component->GetCustomPSOName()),
+   m_billboardType(component->GetBillboardType()),
+   m_billboardAxis(component->GetBillboardAxis())
 {
     if (!m_customPSOName.empty())
     {
@@ -160,7 +162,9 @@ PrimitiveRenderProxy::PrimitiveRenderProxy(const PrimitiveRenderProxy& other) :
         m_quadMesh(other.m_quadMesh),
         m_spriteTexture(other.m_spriteTexture),
         m_customPSOName(other.m_customPSOName),
-        m_customPSO(other.m_customPSO)
+        m_customPSO(other.m_customPSO),
+       m_billboardType(other.m_billboardType),
+       m_billboardAxis(other.m_billboardAxis)
 {
 }
 
@@ -196,7 +200,9 @@ PrimitiveRenderProxy::PrimitiveRenderProxy(PrimitiveRenderProxy&& other) noexcep
         m_quadMesh(std::move(other.m_quadMesh)),
         m_spriteTexture(std::exchange(other.m_spriteTexture, nullptr)),
         m_customPSOName(std::move(other.m_customPSOName)),
-        m_customPSO(std::move(other.m_customPSO))
+        m_customPSO(std::move(other.m_customPSO)),
+       m_billboardType(other.m_billboardType),
+       m_billboardAxis(other.m_billboardAxis)
 {
 }
 

--- a/RenderEngine/MeshRendererProxy.h
+++ b/RenderEngine/MeshRendererProxy.h
@@ -3,6 +3,7 @@
 #include "Transform.h"
 #include "LightMapping.h"
 #include "Animator.h"
+#include "BillboardType.h"
 #ifndef DYNAMICCPP_EXPORTS
 #include "TerrainBuffers.h"
 #include "FoliageType.h"
@@ -129,6 +130,8 @@ public:
 	Texture*						m_spriteTexture{ nullptr };
         std::string m_customPSOName{};
         std::shared_ptr<ShaderPSO>      m_customPSO{ nullptr };
+       BillboardType                          m_billboardType{ BillboardType::None };
+       Mathf::Vector3                         m_billboardAxis{ 0.f, 1.f, 0.f };
 
 private:
 	bool							m_isNeedUpdateCulling{ false };

--- a/RenderEngine/ProxyCommand.cpp
+++ b/RenderEngine/ProxyCommand.cpp
@@ -126,6 +126,8 @@ ProxyCommand::ProxyCommand(SpriteRenderer* pComponent)
 	Mathf::xMatrix worldMatrix = owner->m_transform.GetWorldMatrix();
 	Mathf::Vector3 worldPosition = owner->m_transform.GetWorldPosition();
         std::string customPSOName = componentPtr->GetCustomPSOName();
+       BillboardType billboardType = componentPtr->GetBillboardType();
+       auto billboardAxis = componentPtr->GetBillboardAxis();
 	if (!owner || owner->IsDestroyMark() || pComponent->IsDestroyMark()) return;
 	auto& proxyObject = renderScene->m_proxyMap[m_proxyGUID];
 	if (!proxyObject) return;
@@ -147,6 +149,8 @@ ProxyCommand::ProxyCommand(SpriteRenderer* pComponent)
 		proxyObject->m_isEnableShadow = isEnabled;
                 proxyObject->m_spriteTexture = originTexture;
                 proxyObject->m_customPSOName = customPSOName;
+               proxyObject->m_billboardType = billboardType;
+               proxyObject->m_billboardAxis = billboardAxis;
                 if (!customPSOName.empty())
                 {
                         auto it = ShaderSystem->ShaderAssets.find(customPSOName);

--- a/RenderEngine/SpritePass.cpp
+++ b/RenderEngine/SpritePass.cpp
@@ -1,6 +1,7 @@
 #include "SpritePass.h"
 #include "ShaderSystem.h"
 #include "RenderScene.h"
+#include "BillboardType.h"
 
 SpritePass::SpritePass()
 {
@@ -97,7 +98,20 @@ void SpritePass::CreateRenderCommandList(ID3D11DeviceContext* deferredContext, R
             m_pso->Apply(deferredPtr);
         }
 
-        scene.UpdateModel(proxy->m_worldMatrix, deferredPtr);
+        auto world = proxy->m_worldMatrix;
+        if (proxy->m_billboardType != BillboardType::None)
+        {
+            const auto& pos = proxy->m_worldPosition;
+            if (proxy->m_billboardType == BillboardType::Spherical)
+            {
+                world = Mathf::Matrix::CreateBillboard(pos, camera.m_eyePosition, proxy->m_billboardAxis);
+            }
+            else if (proxy->m_billboardType == BillboardType::Cylindrical)
+            {
+                world = Mathf::Matrix::CreateConstrainedBillboard(pos, camera.m_eyePosition, proxy->m_billboardAxis);
+            }
+        }
+        scene.UpdateModel(world, deferredPtr);
         ID3D11ShaderResourceView* srv = proxy->m_spriteTexture->m_pSRV;
         DirectX11::PSSetShaderResources(deferredPtr, 0, 1, &srv);
         proxy->m_quadMesh->Draw(deferredPtr);

--- a/ScriptBinder/SpriteRenderer.cpp
+++ b/ScriptBinder/SpriteRenderer.cpp
@@ -2,6 +2,7 @@
 #include "Scene.h"
 #include "RenderScene.h"
 #include "SceneManager.h"
+#include "BillboardType.h"
 
 void SpriteRenderer::Awake()
 {

--- a/ScriptBinder/SpriteRenderer.h
+++ b/ScriptBinder/SpriteRenderer.h
@@ -3,6 +3,7 @@
 #include "Component.h"
 #include "IRenderable.h"
 #include "LightMapping.h"
+#include "BillboardType.h"
 #include "SpriteRenderer.generated.h"
 #include "Texture.h"
 
@@ -22,6 +23,10 @@ public:
    const std::shared_ptr<Texture>& GetSprite() const { return m_Sprite; }
    void SetCustomPSOName(const std::string& name) { m_CustomPSOName = name; }
    const std::string& GetCustomPSOName() const { return m_CustomPSOName; }
+   void SetBillboardType(BillboardType type) { m_billboardType = type; }
+   BillboardType GetBillboardType() const noexcept { return m_billboardType; }
+   void SetBillboardAxis(const Mathf::Vector3& axis) { m_billboardAxis = axis; }
+   const Mathf::Vector3& GetBillboardAxis() const noexcept { return m_billboardAxis; }
 
 private:
     [[Property]]
@@ -30,6 +35,10 @@ private:
     std::string m_CustomPSOName{};
     [[Property]]
     int m_orderInLayer{ 0 };
+   [[Property]]
+   BillboardType m_billboardType{ BillboardType::None };
+   [[Property]]
+   Mathf::Vector3 m_billboardAxis{ 0.f, 1.f, 0.f };
 
     std::shared_ptr<Texture> m_Sprite = nullptr;
 };


### PR DESCRIPTION
## Summary
- add shared BillboardType enum
- support spherical and cylindrical billboards in SpriteRenderer and rendering pipeline

## Testing
- `make >/tmp/make.log && tail -n 20 /tmp/make.log`

------
https://chatgpt.com/codex/tasks/task_e_68c3fbe80e34832d82de4c976d2a494f