### PR TITLE
Align UI image origin with RectTransform pivot

### DIFF
--- a/RenderEngine/ProxyCommand.cpp
+++ b/RenderEngine/ProxyCommand.cpp
@@ -344,7 +344,7 @@ ProxyCommand::ProxyCommand(ImageComponent* pComponent)
 	if (iter == renderScene->m_uiProxyMap.end() || !iter->second) return;
 	std::weak_ptr<UIRenderProxy> weakProxyObject = iter->second->shared_from_this();
 
-	DirectX::XMFLOAT2 origin{ pComponent->uiinfo.size.x * 0.5f, pComponent->uiinfo.size.y * 0.5f };
+        DirectX::XMFLOAT2 origin{ pComponent->origin.x, pComponent->origin.y };
 	auto textures	= pComponent->textures;
 	auto curTexture	= pComponent->m_curtexture;
 	auto color		= pComponent->color;

--- a/ScriptBinder/ImageComponent.cpp
+++ b/ScriptBinder/ImageComponent.cpp
@@ -25,9 +25,24 @@ void ImageComponent::SetTexture(int index)
 
 	curindex = index;
 	m_curtexture = textures[curindex];
-	uiinfo.size = textures[curindex]->GetImageSize();
+        uiinfo.size = textures[curindex]->GetImageSize();
 
-	origin = { uiinfo.size.x / 2, uiinfo.size.y / 2 };
+        if (GameObject* owner = m_pOwner)
+        {
+                if (auto* rect = owner->GetComponent<RectTransformComponent>())
+                {
+                        const auto& pivot = rect->GetPivot();
+                        origin = { uiinfo.size.x * pivot.x, uiinfo.size.y * pivot.y };
+                }
+                else
+                {
+                        origin = { uiinfo.size.x * 0.5f, uiinfo.size.y * 0.5f };
+                }
+        }
+        else
+        {
+                origin = { uiinfo.size.x * 0.5f, uiinfo.size.y * 0.5f };
+        }
 }
 
 bool ImageComponent::isThisTextureExist(std::string_view path) const
@@ -82,15 +97,20 @@ void ImageComponent::Update(float tick)
     if (auto* rect = m_pOwner->GetComponent<RectTransformComponent>())
     {
         const auto& worldRect = rect->GetWorldRect();
-        pos = { worldRect.x + worldRect.width * 0.5f,
-                worldRect.y + worldRect.height * 0.5f,
+        const auto& pivot = rect->GetPivot();
+
+        pos = { worldRect.x + worldRect.width * pivot.x,
+                worldRect.y + worldRect.height * pivot.y,
                 0.0f };
         scale = { worldRect.width / uiinfo.size.x,
                   worldRect.height / uiinfo.size.y };
 
-		scale *= unionScale;
+        origin = { uiinfo.size.x * pivot.x,
+                   uiinfo.size.y * pivot.y };
 
-		rect->SetSizeDelta(uiinfo.size);
+        scale *= unionScale;
+
+        rect->SetSizeDelta(uiinfo.size);
     }
 }
 


### PR DESCRIPTION
## Summary
- align ImageComponent origin with its RectTransform pivot when textures are assigned and during layout updates
- propagate the component's stored origin to the UI render proxy so rendering respects the pivot

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ca22312bfc832d8d5cb6ea8e61aff7