### PR TITLE
Add fullsize viewport for BlitPass upscaling

### DIFF
--- a/RenderEngine/BlitPass.cpp
+++ b/RenderEngine/BlitPass.cpp
@@ -55,8 +55,10 @@ void BlitPass::Execute(RenderScene& scene, Camera& camera)
 
     m_pso->Apply();
 
-	ID3D11RenderTargetView* rtv = m_backBufferRTV;
-	DirectX11::OMSetRenderTargets(1, &rtv, nullptr);
+    DirectX11::RSSetViewports(1, &DirectX11::DeviceStates->g_fullsizeViewport);
+
+        ID3D11RenderTargetView* rtv = m_backBufferRTV;
+        DirectX11::OMSetRenderTargets(1, &rtv, nullptr);
 
 	DirectX11::PSSetShaderResources(0, 1, &renderData->m_renderTarget->m_pSRV);
 	DirectX11::Draw(4, 0);

--- a/RenderEngine/DeviceState.h
+++ b/RenderEngine/DeviceState.h
@@ -22,6 +22,7 @@ namespace DirectX11
 		ID3D11RasterizerState*		g_pRasterizerState{};
 		ID3D11BlendState*			g_pBlendState{};
 		D3D11_VIEWPORT				g_Viewport{};
+		D3D11_VIEWPORT			g_fullsizeViewport{};
 		ID3D11RenderTargetView*		g_backBufferRTV{};
 		ID3D11ShaderResourceView*	g_depthStancilSRV{};
 		ID3D11ShaderResourceView*	g_editorDepthStancilSRV{};

--- a/RenderEngine/SceneRenderer.cpp
+++ b/RenderEngine/SceneRenderer.cpp
@@ -327,6 +327,7 @@ void SceneRenderer::InitializeDeviceState()
     DirectX11::DeviceStates->g_pRasterizerState		= m_deviceResources->GetRasterizerState();
     DirectX11::DeviceStates->g_pBlendState			= m_deviceResources->GetBlendState();
     DirectX11::DeviceStates->g_Viewport				= m_deviceResources->GetScreenViewport();
+    DirectX11::DeviceStates->g_fullsizeViewport		= m_deviceResources->GetScreenViewport();
     DirectX11::DeviceStates->g_backBufferRTV		= m_deviceResources->GetBackBufferRenderTargetView();
     DirectX11::DeviceStates->g_depthStancilSRV		= m_deviceResources->GetDepthStencilViewSRV();
     DirectX11::DeviceStates->g_ClientRect			= m_deviceResources->GetOutputSize();
@@ -343,6 +344,7 @@ void SceneRenderer::InitializeDeviceState()
 		DirectX11::DeviceStates->g_pBlendState			= m_deviceResources->GetBlendState();
 		//TODO : 빌드 옵션에 따라서 GameViewport를 사용하게 해야겠네???
 		//DirectX11::DeviceStates->g_Viewport = m_deviceResources->GetScreenViewport();
+		DirectX11::DeviceStates->g_fullsizeViewport	= m_deviceResources->GetScreenViewport();
 		DirectX11::DeviceStates->g_backBufferRTV		= m_deviceResources->GetBackBufferRenderTargetView();
 		DirectX11::DeviceStates->g_depthStancilSRV		= m_deviceResources->GetDepthStencilViewSRV();
 		DirectX11::DeviceStates->g_ClientRect			= m_deviceResources->GetLogicalSize();


### PR DESCRIPTION
## Summary
- add a fullsize viewport field to `DeviceStates` for the current window dimensions
- keep the fullsize viewport in sync during device initialization and resize handling
- drive BlitPass viewport configuration from the fullsize viewport before drawing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d52d1741bc832da365ddae11a9fb95