### PR TITLE
Add menu bar pause control for game mode

### DIFF
--- a/EngineEntry/Dx11Main.cpp
+++ b/EngineEntry/Dx11Main.cpp
@@ -245,7 +245,9 @@ void DirectX11::Dx11Main::CreateWindowSizeDependentResources()
 void DirectX11::Dx11Main::Update()
 {
 	// EditorUpdate
-    EngineSettingInstance->frameDeltaTime = Time->GetElapsedSeconds();
+    const bool isPaused = SceneManagers->IsGamePaused();
+    const double deltaSeconds = Time->GetElapsedSeconds();
+    EngineSettingInstance->frameDeltaTime = isPaused ? 0.0 : deltaSeconds;
 
     PROFILE_CPU_BEGIN("GameLogic");
     Time->Tick([&]
@@ -253,7 +255,7 @@ void DirectX11::Dx11Main::Update()
         InfoWindow();
         InputManagement->Update(EngineSettingInstance->frameDeltaTime);
 #ifdef EDITOR
-        if(!SceneManagers->m_isGameStart)
+        if(!SceneManagers->IsGameStart())
         {
             SceneManagers->Editor();
             SceneManagers->InputEvents(EngineSettingInstance->frameDeltaTime);
@@ -261,11 +263,19 @@ void DirectX11::Dx11Main::Update()
         }
         else
         {
-			SceneManagers->Editor();
+            SceneManagers->Editor();
             SceneManagers->Initialization();
-			SceneManagers->Physics(EngineSettingInstance->frameDeltaTime);
-            SceneManagers->InputEvents(EngineSettingInstance->frameDeltaTime);
-            SceneManagers->GameLogic(EngineSettingInstance->frameDeltaTime);
+
+            if (!SceneManagers->IsGamePaused())
+            {
+                SceneManagers->Physics(EngineSettingInstance->frameDeltaTime);
+                SceneManagers->InputEvents(EngineSettingInstance->frameDeltaTime);
+                SceneManagers->GameLogic(EngineSettingInstance->frameDeltaTime);
+            }
+            else
+            {
+                SceneManagers->Pausing();
+            }
         }
 #endif // !EDITOR
     });

--- a/EngineGUIWindow/MenuBarWindow.cpp
+++ b/EngineGUIWindow/MenuBarWindow.cpp
@@ -461,19 +461,39 @@ void MenuBarWindow::RenderMenuBar()
 
             ImGui::SetCursorPos(ImVec2((availRegion * 0.5f) + 100.f, 1));
 
-            if (ImGui::Button(SceneManagers->m_isGameStart ? ICON_FA_STOP : ICON_FA_PLAY))
+            const bool isGameRunning = SceneManagers->IsGameStart();
+            if (ImGui::Button(isGameRunning ? ICON_FA_STOP : ICON_FA_PLAY))
             {
                 Meta::UndoCommandManager->ClearGameMode();
-				SceneManagers->m_isGameStart = !SceneManagers->m_isGameStart;
-				Meta::UndoCommandManager->m_isGameMode = SceneManagers->m_isGameStart;
+                SceneManagers->SetGameStart(!isGameRunning);
+                Meta::UndoCommandManager->m_isGameMode = SceneManagers->IsGameStart();
             }
 
             ImVec2 curPos = ImGui::GetCursorPos();
             ImGui::SetCursorPos(ImVec2(curPos.x, 1));
 
-			if (ImGui::Button(ICON_FA_PAUSE))
-			{
-			}
+            const bool canPause = SceneManagers->IsGameStart();
+            ImGui::BeginDisabled(!canPause);
+            const bool isPaused = SceneManagers->IsGamePaused();
+            if (canPause && isPaused)
+            {
+                const ImVec4 active = ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive);
+                ImGui::PushStyleColor(ImGuiCol_Button, active);
+                ImGui::PushStyleColor(ImGuiCol_ButtonHovered, active);
+                ImGui::PushStyleColor(ImGuiCol_ButtonActive, active);
+            }
+
+            const char* pauseIcon = isPaused ? ICON_FA_PLAY : ICON_FA_PAUSE;
+            if (ImGui::Button(pauseIcon))
+            {
+                SceneManagers->ToggleGamePaused();
+            }
+
+            if (canPause && isPaused)
+            {
+                ImGui::PopStyleColor(3);
+            }
+            ImGui::EndDisabled();
 
             ImGui::SetCursorPosX(ImGui::GetWindowContentRegionMax().x - 40.0f);
             bool style = static_cast<bool>(DataSystems->GetContentsBrowserStyle());

--- a/ScriptBinder/SceneManager.cpp
+++ b/ScriptBinder/SceneManager.cpp
@@ -13,11 +13,43 @@
 #include "ReflectionRegister.h"
 #include <algorithm>
 #include "IRegistableEvent.h"
+#include "TimeSystem.h"
+
+void SceneManager::SetGameStart(bool isStart)
+{
+    if (!isStart)
+    {
+        SetGamePaused(false);
+    }
+
+    m_isGameStart = isStart;
+}
+
+void SceneManager::SetGamePaused(bool isPaused)
+{
+    if (!m_isGameStart && isPaused)
+    {
+        return;
+    }
+
+    const bool previousState = m_isGamePaused.exchange(isPaused);
+    if (previousState == isPaused)
+    {
+        return;
+    }
+
+    Time->ResetElapsedTime();
+}
+
+void SceneManager::ToggleGamePaused()
+{
+    SetGamePaused(!IsGamePaused());
+}
 
 void SceneManager::ManagerInitialize()
 {
     REFLECTION_REGISTER_EXECUTE();
-	ComponentFactorys->Initialize();
+        ComponentFactorys->Initialize();
 	m_threadPool = new ThreadPool;
     m_inputActionManager = new InputActionManager();
     InputActionManagers = m_inputActionManager;
@@ -417,8 +449,8 @@ Scene* SceneManager::LoadSceneImmediate(std::string_view name)
 		activeSceneChangedEvent.Broadcast();
 		sceneLoadedEvent.Broadcast();
 #ifdef BUILD_FLAG
-        SceneManagers->m_isGameStart = true;
-		std::cout << "Scene loaded: " << loadSceneName << std::endl;
+        SceneManagers->SetGameStart(true);
+                std::cout << "Scene loaded: " << loadSceneName << std::endl;
 #endif
         m_activeScene.load()->Reset();
 	}

--- a/ScriptBinder/SceneManager.h
+++ b/ScriptBinder/SceneManager.h
@@ -60,7 +60,11 @@ public:
 	void SetActiveSceneIndex(size_t index) { m_activeSceneIndex = index; }
 	size_t GetActiveSceneIndex() { return m_activeSceneIndex; }
 	bool IsGameStart() const { return m_isGameStart; }
-	void SetGameStart(bool isStart) { m_isGameStart = isStart; }
+	void SetGameStart(bool isStart);
+
+	bool IsGamePaused() const { return m_isGamePaused; }
+	void SetGamePaused(bool isPaused);
+	void ToggleGamePaused();
 
 	bool IsEditorSceneLoaded() const { return m_isEditorSceneLoaded; }
     InputActionManager* GetInputActionManager() { return m_inputActionManager; }
@@ -94,6 +98,7 @@ public:
 	Core::Delegate<void>                AssetLoadEvent{};
 
     std::atomic_bool                    m_isGameStart{ false };
+    std::atomic_bool                    m_isGamePaused{ false };
 	std::atomic_bool			        m_isEditorSceneLoaded{ false };
 	std::atomic_bool                    m_isInitialized{ false };
 	size_t 					            m_EditorSceneIndex{ 0 };
@@ -101,7 +106,7 @@ public:
     ThreadPool<std::function<void()>>*  m_threadPool{ nullptr };
 
     std::future<Scene*>                 m_loadingSceneFuture;
-    InputActionManager*                 m_inputActionManager{ nullptr };  //TODO: »èÁ¦Ã³¸® ¾øÀ½ ÇÊ¿ä½Ã Ãß°¡ÇØ¾ßÇÔ //sehwan&&&&&
+    InputActionManager*                 m_inputActionManager{ nullptr };  //TODO: ì‚­ì œì²˜ë¦¬ ì—†ìŒ í•„ìš”ì‹œ ì¶”ê°€í•´ì•¼í•¨ //sehwan&&&&&
 private:
     void CreateEditorOnlyPlayScene();
 	void DeleteEditorOnlyPlayScene();

--- a/TrainAsis/TrainAsis/GameMain.cpp
+++ b/TrainAsis/TrainAsis/GameMain.cpp
@@ -184,7 +184,9 @@ void DirectX11::GameMain::CreateWindowSizeDependentResources()
 void DirectX11::GameMain::Update()
 {
     // EditorUpdate
-    EngineSettingInstance->frameDeltaTime = Time->GetElapsedSeconds();
+    const bool isPaused = SceneManagers->IsGamePaused();
+    const double deltaSeconds = Time->GetElapsedSeconds();
+    EngineSettingInstance->frameDeltaTime = isPaused ? 0.0 : deltaSeconds;
 
     Time->Tick([&]
     {
@@ -192,9 +194,16 @@ void DirectX11::GameMain::Update()
         InputManagement->Update(EngineSettingInstance->frameDeltaTime);
 
         SceneManagers->Initialization();
-        SceneManagers->Physics(EngineSettingInstance->frameDeltaTime);
-        SceneManagers->InputEvents(EngineSettingInstance->frameDeltaTime);
-        SceneManagers->GameLogic(EngineSettingInstance->frameDeltaTime);
+        if (!SceneManagers->IsGamePaused())
+        {
+            SceneManagers->Physics(EngineSettingInstance->frameDeltaTime);
+            SceneManagers->InputEvents(EngineSettingInstance->frameDeltaTime);
+            SceneManagers->GameLogic(EngineSettingInstance->frameDeltaTime);
+        }
+        else
+        {
+            SceneManagers->Pausing();
+        }
     });
 
     EngineSettingInstance->renderBarrier.ArriveAndWait();


### PR DESCRIPTION
## Summary
- add explicit game pause state management to `SceneManager`
- hook the menu bar pause button to toggle the new pause state while updating undo/play mode flags
- halt physics, input, and game logic updates when paused in both editor and runtime loops

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68eda22284e4832d99e3ce74b8e94677