### PR TITLE
Add Mono binding for Component

### DIFF
--- a/Assembly-CSharp/Assembly-CSharp/Assembly-CSharp/Class/Component.cs
+++ b/Assembly-CSharp/Assembly-CSharp/Assembly-CSharp/Class/Component.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace CreatorEngine
+{
+    public class Component : Object
+    {
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern IntPtr ICall_GetOwner(IntPtr self);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern IntPtr ICall_GetComponent(IntPtr self, ulong typeGuid);
+
+        public GameObject? Owner
+        {
+            get
+            {
+                IntPtr ownerPtr = ICall_GetOwner(m_NativePtr);
+                if (ownerPtr == IntPtr.Zero)
+                {
+                    return null;
+                }
+
+                var owner = new GameObject();
+                owner.m_NativePtr = ownerPtr;
+                return owner;
+            }
+        }
+
+        public Component? GetComponent(ulong typeGuid)
+        {
+            IntPtr componentPtr = ICall_GetComponent(m_NativePtr, typeGuid);
+            if (componentPtr == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            var component = new Component();
+            component.m_NativePtr = componentPtr;
+            return component;
+        }
+    }
+}

--- a/Assembly-CSharp/Assembly-CSharp/Assembly-CSharp/Class/GameObject.cs
+++ b/Assembly-CSharp/Assembly-CSharp/Assembly-CSharp/Class/GameObject.cs
@@ -1,0 +1,6 @@
+namespace CreatorEngine
+{
+    public class GameObject : Object
+    {
+    }
+}

--- a/ScriptBinder/Component_Binding.h
+++ b/ScriptBinder/Component_Binding.h
@@ -1,0 +1,60 @@
+#pragma once
+#ifndef UNUSE_MONO_LIB
+
+#include <mono/jit/jit.h>
+#include <mono/metadata/assembly.h>
+#include <mono/metadata/mono-config.h>
+#include <mono/metadata/object.h>
+
+#include "Component.h"
+#include "GameObject.h"
+#include "TypeTrait.h"
+#include <cstdint>
+#include <exception>
+
+namespace
+{
+    inline Component* FromIntPtr(MonoObject* /*instance*/, intptr_t nativePtr) noexcept
+    {
+        return reinterpret_cast<Component*>(nativePtr);
+    }
+
+    extern "C"
+    {
+        static intptr_t ICall_Component_GetOwner(MonoObject* _this, intptr_t nativePtr) noexcept
+        {
+            if (auto* self = FromIntPtr(_this, nativePtr))
+            {
+                if (auto* owner = self->GetOwner())
+                {
+                    return reinterpret_cast<intptr_t>(owner);
+                }
+            }
+            return 0;
+        }
+
+        static intptr_t ICall_Component_GetComponent(MonoObject* _this, intptr_t nativePtr, uint64_t typeGuid) noexcept
+        {
+            if (auto* self = FromIntPtr(_this, nativePtr))
+            {
+                try
+                {
+                    Component& component = self->GetComponent(HashedGuid{ static_cast<size_t>(typeGuid) });
+                    return reinterpret_cast<intptr_t>(&component);
+                }
+                catch (const std::exception&)
+                {
+                }
+            }
+            return 0;
+        }
+    }
+}
+
+inline void Register_Component_ICalls()
+{
+    mono_add_internal_call("CreatorEngine.Component::ICall_GetOwner", (const void*)ICall_Component_GetOwner);
+    mono_add_internal_call("CreatorEngine.Component::ICall_GetComponent", (const void*)ICall_Component_GetComponent);
+}
+
+#endif // !UNUSE_MONO_LIB

--- a/ScriptBinder/MonoManager.cpp
+++ b/ScriptBinder/MonoManager.cpp
@@ -1,32 +1,32 @@
 #include "MonoManager.h"
 #ifndef UNUSE_MONO_LIB
+#include "Object_Binding.h"
+#include "Component_Binding.h"
 #include <cassert>
 #include <sstream>
 #include <iostream>
 #include <mono/metadata/mono-gc.h>
 #include <mono/metadata/threads.h>
 
-// ³×°¡ ±âÁ¸¿¡ ÀÛ¼ºÇÑ Object ¹ÙÀÎµù µî·Ï ÇÔ¼ö
-void Register_Object_ICalls();
 
 bool MonoManager::Initialize(const char* domainName,
     const char* monoLibDir,
     const char* monoEtcDir,
     bool enableDebug)
 {
-    // Mono ¿£Áø °æ·Î ¼³Á¤
+    // Mono ì—”ì§„ ê²½ë¡œ ì„¤ì •
     mono_set_dirs(monoLibDir, monoEtcDir);
     mono_config_parse(nullptr);
 
     if (enableDebug)
     {
-        // mdb/pdb ½Éº¼ ·Îµù È°¼ºÈ­
+        // mdb/pdb ì‹¬ë³¼ ë¡œë”© í™œì„±í™”
         mono_debug_init(MONO_DEBUG_FORMAT_MONO);
-        mono_jit_set_aot_mode(MONO_AOT_MODE_INTERP); // ÇÊ¿ä½Ã ÀÎÅÍÇÁ¸®ÅÍ º´Çà
+        mono_jit_set_aot_mode(MONO_AOT_MODE_INTERP); // í•„ìš”ì‹œ ì¸í„°í”„ë¦¬í„° ë³‘í–‰
         mono_debug_domain_create(mono_get_root_domain());
     }
 
-    // ·çÆ® µµ¸ŞÀÎ »ı¼º
+    // ë£¨íŠ¸ ë„ë©”ì¸ ìƒì„±
     m_rootDomain = mono_jit_init_version(domainName, "v4.0.30319");
     if (!m_rootDomain)
     {
@@ -34,11 +34,11 @@ bool MonoManager::Initialize(const char* domainName,
         return false;
     }
 
-    // ¾Û µµ¸ŞÀÎ »ı¼º (½ºÅ©¸³Æ®¿ë µµ¸ŞÀÎ ºĞ¸®)
+    // ì•± ë„ë©”ì¸ ìƒì„± (ìŠ¤í¬ë¦½íŠ¸ìš© ë„ë©”ì¸ ë¶„ë¦¬)
     if (!CreateAppDomain(domainName))
         return false;
 
-    // ³»ºÎ È£Ãâ µî·Ï (ÇÊ¿äÇÑ ¹ÙÀÎµù ¸ğµÎ ¿©±â¿¡¼­)
+    // ë‚´ë¶€ í˜¸ì¶œ ë“±ë¡ (í•„ìš”í•œ ë°”ì¸ë”© ëª¨ë‘ ì—¬ê¸°ì—ì„œ)
     RegisterInternalCalls();
     return true;
 }
@@ -75,7 +75,7 @@ void MonoManager::DestroyAppDomain()
 {
     if (m_appDomain)
     {
-        // appdomain unload´Â ·çÆ® µµ¸ŞÀÎ ÄÁÅØ½ºÆ®¿¡¼­ ½ÇÇàÇØ¾ß ÇÔ
+        // appdomain unloadëŠ” ë£¨íŠ¸ ë„ë©”ì¸ ì»¨í…ìŠ¤íŠ¸ì—ì„œ ì‹¤í–‰í•´ì•¼ í•¨
         mono_domain_set(m_rootDomain, /* force */ false);
         mono_domain_unload(m_appDomain);
         m_appDomain = nullptr;
@@ -115,35 +115,35 @@ MonoManager::LoadAssembly(const std::string& name, const std::string& path)
 
 void MonoManager::UnloadAllAssemblies()
 {
-    // Mono API·Î °³º° ¾î¼Àºí¸® unload´Â ¾È µÊ. AppDomainÀ» ÅëÂ°·Î ¾ğ·ÎµåÇØ¾ß ÇÔ.
+    // Mono APIë¡œ ê°œë³„ ì–´ì…ˆë¸”ë¦¬ unloadëŠ” ì•ˆ ë¨. AppDomainì„ í†µì§¸ë¡œ ì–¸ë¡œë“œí•´ì•¼ í•¨.
     m_assemblies.clear();
 }
 
 bool MonoManager::ReloadAll(const std::vector<std::pair<std::string, std::string>>& assemblies)
 {
-    // 1) ±âÁ¸ AppDomain ÆÄ±«
+    // 1) ê¸°ì¡´ AppDomain íŒŒê´´
     UnloadAllAssemblies();
     DestroyAppDomain();
 
-    // 2) »õ AppDomain »ı¼º
+    // 2) ìƒˆ AppDomain ìƒì„±
     if (!CreateAppDomain("ScriptDomain"))
         return false;
 
-    // 3) Àç·Îµù
+    // 3) ì¬ë¡œë”©
     for (auto& p : assemblies)
     {
         auto opt = LoadAssembly(p.first, p.second);
         if (!opt) return false;
     }
 
-    // 4) ³»ºÎ È£Ãâ Àçµî·Ï(µµ¸ŞÀÎ¸¶´Ù ÇÊ¿ä)
+    Register_Component_ICalls();
     RegisterInternalCalls();
     return true;
 }
 
 MonoThread* MonoManager::AttachCurrentThread()
 {
-    // ÀÌ¹Ì ºÙ¾î ÀÖÀ¸¸é nullptr ¹İÈ¯ °¡´É. Attach º¸Àå À§ÇØ °á°ú Ã¼Å©´Â »ı·«
+    // ì´ë¯¸ ë¶™ì–´ ìˆìœ¼ë©´ nullptr ë°˜í™˜ ê°€ëŠ¥. Attach ë³´ì¥ ìœ„í•´ ê²°ê³¼ ì²´í¬ëŠ” ìƒëµ
     return mono_thread_attach(m_appDomain);
 }
 
@@ -154,7 +154,7 @@ void MonoManager::DetachCurrentThread()
 
 void MonoManager::RegisterInternalCalls()
 {
-    // ¿©±â¿¡ ¿£ÁøÀÇ ¸ğµç ¹ÙÀÎµù µî·Ï ÇÔ¼ö È£Ãâ
+    // ì—¬ê¸°ì— ì—”ì§„ì˜ ëª¨ë“  ë°”ì¸ë”© ë“±ë¡ í•¨ìˆ˜ í˜¸ì¶œ
     Register_Object_ICalls();
     // Register_Component_ICalls();
     // Register_Transform_ICalls();
@@ -165,8 +165,8 @@ MonoClass* MonoManager::GetClass(const char* nameSpace, const char* klassName, M
 {
     if (!image)
     {
-        // ±âº»: Ã¹ ¹øÂ°(¶Ç´Â Æ¯Á¤) ½ºÅ©¸³Æ® ¾î¼Àºí¸® ÀÌ¹ÌÁö »ç¿ëÇÏ°í ½ÍÀ¸¸é ÀÌ¸§À» ÅëÀÏÇØ¼­ ²¨³» ¾²ÀÚ.
-        // ¿©±â¼± ´ë·« Ã¹ ¹øÂ° ¿£Æ®¸®¸¦ »ç¿ë
+        // ê¸°ë³¸: ì²« ë²ˆì§¸(ë˜ëŠ” íŠ¹ì •) ìŠ¤í¬ë¦½íŠ¸ ì–´ì…ˆë¸”ë¦¬ ì´ë¯¸ì§€ ì‚¬ìš©í•˜ê³  ì‹¶ìœ¼ë©´ ì´ë¦„ì„ í†µì¼í•´ì„œ êº¼ë‚´ ì“°ì.
+        // ì—¬ê¸°ì„  ëŒ€ëµ ì²« ë²ˆì§¸ ì—”íŠ¸ë¦¬ë¥¼ ì‚¬ìš©
         if (m_assemblies.empty()) return nullptr;
         image = m_assemblies.begin()->second.image;
     }
@@ -201,7 +201,7 @@ MonoObject* MonoManager::CreateInstance(MonoClass* klass)
     if (!klass) return nullptr;
     MonoObject* obj = mono_object_new(m_appDomain, klass);
     if (!obj) return nullptr;
-    mono_runtime_object_init(obj); // .ctor() È£Ãâ
+    mono_runtime_object_init(obj); // .ctor() í˜¸ì¶œ
     return obj;
 }
 
@@ -262,8 +262,8 @@ void MonoManager::GCCollect()
 
 void MonoManager::GCWaitForPendingFinalizers()
 {
-    // corlib(mscorlib) ÀÌ¹ÌÁö¿¡¼­ System.GC Å¬·¡½º¸¦ Á÷Á¢ ¾ò¾î È£Ãâ
-    MonoImage* corlib = mono_get_corlib(); // corlib ÀÌ¹ÌÁö ÇÚµé
+    // corlib(mscorlib) ì´ë¯¸ì§€ì—ì„œ System.GC í´ë˜ìŠ¤ë¥¼ ì§ì ‘ ì–»ì–´ í˜¸ì¶œ
+    MonoImage* corlib = mono_get_corlib(); // corlib ì´ë¯¸ì§€ í•¸ë“¤
     if (!corlib) {
         std::cerr << "[Mono] corlib image not found\n";
         return;

--- a/ScriptBinder/MonoManager.h
+++ b/ScriptBinder/MonoManager.h
@@ -1,5 +1,4 @@
 #pragma once
-#define UNUSE_MONO_LIB // ¸ğ³ë °ü·Ã ±â´É Æ®¸®°Å
 #ifndef UNUSE_MONO_LIB
 #include <DLLAcrossSingleton.h>
 #include <string>
@@ -25,53 +24,53 @@ public:
     };
 
 public:
-    // ÇÊ¼ö ¼ö¸íÁÖ±â
+    // í•„ìˆ˜ ìˆ˜ëª…ì£¼ê¸°
     bool Initialize(const char* domainName,
         const char* monoLibDir,      // ex) "<mono>/lib"
         const char* monoEtcDir,      // ex) "<mono>/etc"
-        bool enableDebug = false);   // mdb/pdb ½Éº¼ Áö¿ø
+        bool enableDebug = false);   // mdb/pdb ì‹¬ë³¼ ì§€ì›
 
     void Shutdown();
 
-    // ¾î¼Àºí¸® ·Îµå/Àç·Îµù
+    // ì–´ì…ˆë¸”ë¦¬ ë¡œë“œ/ì¬ë¡œë”©
     std::optional<AssemblyPack> LoadAssembly(const std::string& name, const std::string& path);
     void UnloadAllAssemblies();
     bool ReloadAll(const std::vector<std::pair<std::string, std::string>>& assemblies);
 
-    // ±âº» µµ¸ŞÀÎ/µµ¸ŞÀÎ Á¤º¸
+    // ê¸°ë³¸ ë„ë©”ì¸/ë„ë©”ì¸ ì •ë³´
     MonoDomain* GetRootDomain() const { return m_rootDomain; }
     MonoDomain* GetAppDomain()  const { return m_appDomain; }
 
-    // ½º·¹µå °ü¸®
+    // ìŠ¤ë ˆë“œ ê´€ë¦¬
     MonoThread* AttachCurrentThread();
     void        DetachCurrentThread();
 
-    // ³»ºÎ È£Ãâ µî·Ï(¿©±â¼­ ÇÑ ¹ø¿¡)
+    // ë‚´ë¶€ í˜¸ì¶œ ë“±ë¡(ì—¬ê¸°ì„œ í•œ ë²ˆì—)
     void RegisterInternalCalls();
 
-    // Å¬·¡½º/¸Ş¼­µå µµ¿ì¹Ì
+    // í´ë˜ìŠ¤/ë©”ì„œë“œ ë„ìš°ë¯¸
     MonoClass* GetClass(const char* nameSpace, const char* klassName, MonoImage* image = nullptr) const;
     MonoMethod* GetMethod(MonoClass* klass, const char* methodName, int paramCount) const;
 
-    // Á¤Àû ¸Ş¼­µå È£Ãâ
+    // ì •ì  ë©”ì„œë“œ í˜¸ì¶œ
     MonoObject* InvokeStatic(MonoClass* klass, const char* methodName, void** args, int paramCount, MonoObject** outException = nullptr);
 
-    // ÀÎ½ºÅÏ½º »ı¼º/¸Ş¼­µå È£Ãâ
+    // ì¸ìŠ¤í„´ìŠ¤ ìƒì„±/ë©”ì„œë“œ í˜¸ì¶œ
     MonoObject* CreateInstance(MonoClass* klass);
     MonoObject* Invoke(MonoObject* instance, const char* methodName, void** args, int paramCount, MonoObject** outException = nullptr);
 
-    // ¹®ÀÚ¿­ º¯È¯
+    // ë¬¸ìì—´ ë³€í™˜
     MonoString* ToMonoString(const std::string& s) const;
     std::string FromMonoString(MonoString* ms) const;
 
-    // ¿¹¿Ü Æ÷¸Ë Ãâ·Â
+    // ì˜ˆì™¸ í¬ë§· ì¶œë ¥
     static std::string FormatException(MonoObject* exception);
 
-    // GC/À¯Æ¿
+    // GC/ìœ í‹¸
     void GCCollect();
     void GCWaitForPendingFinalizers();
 
-    // ÀÌ¹ÌÁö/¾î¼Àºí¸® Á¢±Ù
+    // ì´ë¯¸ì§€/ì–´ì…ˆë¸”ë¦¬ ì ‘ê·¼
     MonoImage* GetImage(const std::string& assemblyName) const;
 
 private:

--- a/ScriptBinder/Object_Binding.h
+++ b/ScriptBinder/Object_Binding.h
@@ -1,5 +1,4 @@
 #pragma once
-#define UNUSE_MONO_LIB // ¸ğ³ë °ü·Ã ±â´É Æ®¸®°Å
 #ifndef UNUSE_MONO_LIB
 
 // Object_Bindings.cpp
@@ -7,7 +6,7 @@
 #include <mono/metadata/assembly.h>
 #include <mono/metadata/mono-config.h>
 #include <mono/metadata/object.h>
-#include "Object.h"          // ³×°¡ ÁØ Object ¼±¾ğ
+#include "Object.h"          // ë„¤ê°€ ì¤€ Object ì„ ì–¸
 #include "TypeTrait.h"
 
 namespace
@@ -33,7 +32,7 @@ namespace
         return reinterpret_cast<Object*>(nativePtr);
     }
 
-    // -------- ICalls (extern "C" ±ÇÀå) --------
+    // -------- ICalls (extern "C" ê¶Œì¥) --------
     extern "C"
     {
         // ulong GetInstanceID(IntPtr self)
@@ -120,10 +119,10 @@ namespace
     }
 } // anonymous namespace
 
-// --- µî·Ï ÇÔ¼ö (µµ¸ŞÀÎ ÃÊ±âÈ­ ½Ã ÇÑ ¹ø È£Ãâ) ---
+// --- ë“±ë¡ í•¨ìˆ˜ (ë„ë©”ì¸ ì´ˆê¸°í™” ì‹œ í•œ ë²ˆ í˜¸ì¶œ) ---
 void Register_Object_ICalls()
 {
-    // C# Á¤±Ô¸í: "³×ÀÓ½ºÆäÀÌ½º.Å¸ÀÔ::¸Ş¼­µå¸í"
+    // C# ì •ê·œëª…: "ë„¤ì„ìŠ¤í˜ì´ìŠ¤.íƒ€ì…::ë©”ì„œë“œëª…"
     mono_add_internal_call("CreatorEngine.Object::ICall_GetInstanceID", (const void*)ICall_Object_GetInstanceID);
     mono_add_internal_call("CreatorEngine.Object::ICall_GetTypeID", (const void*)ICall_Object_GetTypeID);
     mono_add_internal_call("CreatorEngine.Object::ICall_ToString", (const void*)ICall_Object_ToString);

--- a/ScriptBinder/ScriptBinder.vcxproj
+++ b/ScriptBinder/ScriptBinder.vcxproj
@@ -310,6 +310,7 @@
     <ClInclude Include="MSBuildHelper.h" />
     <ClInclude Include="Navigation.h" />
     <ClInclude Include="Object_Binding.h" />
+    <ClInclude Include="Component_Binding.h" />
     <ClInclude Include="RectTransformComponent.h" />
     <ClInclude Include="CurvePoint.h" />
     <ClInclude Include="ScriptStringModule.h" />

--- a/ScriptBinder/ScriptBinder.vcxproj.filters
+++ b/ScriptBinder/ScriptBinder.vcxproj.filters
@@ -673,6 +673,9 @@
     <ClInclude Include="Object_Binding.h">
       <Filter>Managers\HotLoadSystem\MonoLibSystem\Test</Filter>
     </ClInclude>
+    <ClInclude Include="Component_Binding.h">
+      <Filter>Managers\HotLoadSystem\MonoLibSystem\Test</Filter>
+    </ClInclude>
     <ClInclude Include="MonoManager.h">
       <Filter>Managers\HotLoadSystem\MonoLibSystem</Filter>
     </ClInclude>


### PR DESCRIPTION
## Summary
- stop locally disabling Mono bindings so the headers are compiled when the feature is enabled
- add Component-specific internal calls and register them alongside the existing Object bindings
- introduce managed Component and GameObject wrappers for the Mono side and include the new binding in the project files

## Testing
- not run (tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_69073e300dbc832d9600a6e38607ea52