### PR TITLE
Add Mono GameObject bindings and gate usage in engine

### DIFF
--- a/Assembly-CSharp/Assembly-CSharp/Assembly-CSharp/Class/GameObject.cs
+++ b/Assembly-CSharp/Assembly-CSharp/Assembly-CSharp/Class/GameObject.cs
@@ -1,6 +1,102 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
 namespace CreatorEngine
 {
     public class GameObject : Object
     {
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern IntPtr ICall_Find(string name);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern IntPtr ICall_FindIndex(int index);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern IntPtr ICall_GetComponent(IntPtr self, uint typeGuid);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern string ICall_GetTag(IntPtr self);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern void ICall_SetTag(IntPtr self, string tag);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern string ICall_GetLayer(IntPtr self);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern void ICall_SetLayer(IntPtr self, string layer);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern bool ICall_GetStatic(IntPtr self);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern void ICall_SetStatic(IntPtr self, bool value);
+
+        public static GameObject? Find(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                return null;
+            }
+
+            IntPtr nativePtr = ICall_Find(name);
+            if (nativePtr == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            var gameObject = new GameObject();
+            gameObject.m_NativePtr = nativePtr;
+            return gameObject;
+        }
+
+        public static GameObject? FindIndex(int index)
+        {
+            if (index < 0)
+            {
+                return null;
+            }
+
+            IntPtr nativePtr = ICall_FindIndex(index);
+            if (nativePtr == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            var gameObject = new GameObject();
+            gameObject.m_NativePtr = nativePtr;
+            return gameObject;
+        }
+
+        public Component? GetComponent(uint typeGuid)
+        {
+            IntPtr componentPtr = ICall_GetComponent(m_NativePtr, typeGuid);
+            if (componentPtr == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            var component = new Component();
+            component.m_NativePtr = componentPtr;
+            return component;
+        }
+
+        public string Tag
+        {
+            get => ICall_GetTag(m_NativePtr);
+            set => ICall_SetTag(m_NativePtr, value ?? string.Empty);
+        }
+
+        public string Layer
+        {
+            get => ICall_GetLayer(m_NativePtr);
+            set => ICall_SetLayer(m_NativePtr, value ?? string.Empty);
+        }
+
+        public bool IsStatic
+        {
+            get => ICall_GetStatic(m_NativePtr);
+            set => ICall_SetStatic(m_NativePtr, value);
+        }
     }
 }

--- a/EngineEntry/framework.h
+++ b/EngineEntry/framework.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#define UNUSE_MONO_LIB
+
 #include "targetver.h"
 #define WIN32_LEAN_AND_MEAN             // 거의 사용되지 않는 내용을 Windows 헤더에서 제외합니다.
 // Windows 헤더 파일

--- a/ScriptBinder/Component_Binding.h
+++ b/ScriptBinder/Component_Binding.h
@@ -1,5 +1,4 @@
 #pragma once
-#define UNUSE_MONO_LIB
 #ifndef UNUSE_MONO_LIB
 #include "FormIntPtr.h"
 #include "Component.h"

--- a/ScriptBinder/FormIntPtr.h
+++ b/ScriptBinder/FormIntPtr.h
@@ -1,5 +1,4 @@
 #pragma once
-#define UNUSE_MONO_LIB
 #ifndef UNUSE_MONO_LIB
 #include <mono/jit/jit.h>
 #include <mono/metadata/assembly.h>

--- a/ScriptBinder/GameObject_Binding.h
+++ b/ScriptBinder/GameObject_Binding.h
@@ -1,0 +1,146 @@
+#pragma once
+#ifndef UNUSE_MONO_LIB
+
+#include "FormIntPtr.h"
+#include "GameObject.h"
+#include "Component.h"
+#include "TypeTrait.h"
+
+#include <cstdint>
+#include <string>
+
+namespace
+{
+    inline std::string MonoToUTF8(MonoString* mstr)
+    {
+        if (!mstr)
+        {
+            return {};
+        }
+
+        char* utf8 = mono_string_to_utf8(mstr);
+        std::string out = utf8 ? utf8 : "";
+        if (utf8)
+        {
+            mono_free(utf8);
+        }
+        return out;
+    }
+
+    inline MonoString* UTF8ToMono(const std::string& value)
+    {
+        return mono_string_new(mono_domain_get(), value.c_str());
+    }
+
+    extern "C"
+    {
+        static intptr_t ICall_GameObject_Find(MonoObject* /*klass*/, MonoString* mname)
+        {
+            const std::string name = MonoToUTF8(mname);
+            if (name.empty())
+            {
+                return 0;
+            }
+
+            if (GameObject* found = GameObject::Find(name))
+            {
+                return reinterpret_cast<intptr_t>(found);
+            }
+            return 0;
+        }
+
+        static intptr_t ICall_GameObject_FindIndex(MonoObject* /*klass*/, int32_t index)
+        {
+            if (index < 0)
+            {
+                return 0;
+            }
+
+            if (GameObject* found = GameObject::FindIndex(index))
+            {
+                return reinterpret_cast<intptr_t>(found);
+            }
+            return 0;
+        }
+
+        static intptr_t ICall_GameObject_GetComponent(MonoObject* _this, intptr_t nativePtr, uint32_t typeId) noexcept
+        {
+            if (auto* self = FromIntPtr<GameObject>(_this, nativePtr))
+            {
+                if (auto component = self->GetComponentByTypeID(typeId))
+                {
+                    return reinterpret_cast<intptr_t>(component.get());
+                }
+            }
+            return 0;
+        }
+
+        static MonoString* ICall_GameObject_GetTag(MonoObject* _this, intptr_t nativePtr)
+        {
+            if (auto* self = FromIntPtr<GameObject>(_this, nativePtr))
+            {
+                return UTF8ToMono(self->m_tag.ToString());
+            }
+            return UTF8ToMono(std::string{});
+        }
+
+        static void ICall_GameObject_SetTag(MonoObject* _this, intptr_t nativePtr, MonoString* mtag)
+        {
+            if (auto* self = FromIntPtr<GameObject>(_this, nativePtr))
+            {
+                const std::string tag = MonoToUTF8(mtag);
+                self->SetTag(tag);
+            }
+        }
+
+        static MonoString* ICall_GameObject_GetLayer(MonoObject* _this, intptr_t nativePtr)
+        {
+            if (auto* self = FromIntPtr<GameObject>(_this, nativePtr))
+            {
+                return UTF8ToMono(self->m_layer.ToString());
+            }
+            return UTF8ToMono(std::string{});
+        }
+
+        static void ICall_GameObject_SetLayer(MonoObject* _this, intptr_t nativePtr, MonoString* mlayer)
+        {
+            if (auto* self = FromIntPtr<GameObject>(_this, nativePtr))
+            {
+                const std::string layer = MonoToUTF8(mlayer);
+                self->SetLayer(layer);
+            }
+        }
+
+        static mono_bool ICall_GameObject_GetStatic(MonoObject* _this, intptr_t nativePtr)
+        {
+            if (auto* self = FromIntPtr<GameObject>(_this, nativePtr))
+            {
+                return self->IsStatic() ? 1 : 0;
+            }
+            return 0;
+        }
+
+        static void ICall_GameObject_SetStatic(MonoObject* _this, intptr_t nativePtr, mono_bool value)
+        {
+            if (auto* self = FromIntPtr<GameObject>(_this, nativePtr))
+            {
+                self->SetStatic(value != 0);
+            }
+        }
+    }
+}
+
+inline void Register_GameObject_ICalls()
+{
+    mono_add_internal_call("CreatorEngine.GameObject::ICall_Find", (const void*)ICall_GameObject_Find);
+    mono_add_internal_call("CreatorEngine.GameObject::ICall_FindIndex", (const void*)ICall_GameObject_FindIndex);
+    mono_add_internal_call("CreatorEngine.GameObject::ICall_GetComponent", (const void*)ICall_GameObject_GetComponent);
+    mono_add_internal_call("CreatorEngine.GameObject::ICall_GetTag", (const void*)ICall_GameObject_GetTag);
+    mono_add_internal_call("CreatorEngine.GameObject::ICall_SetTag", (const void*)ICall_GameObject_SetTag);
+    mono_add_internal_call("CreatorEngine.GameObject::ICall_GetLayer", (const void*)ICall_GameObject_GetLayer);
+    mono_add_internal_call("CreatorEngine.GameObject::ICall_SetLayer", (const void*)ICall_GameObject_SetLayer);
+    mono_add_internal_call("CreatorEngine.GameObject::ICall_GetStatic", (const void*)ICall_GameObject_GetStatic);
+    mono_add_internal_call("CreatorEngine.GameObject::ICall_SetStatic", (const void*)ICall_GameObject_SetStatic);
+}
+
+#endif // !UNUSE_MONO_LIB

--- a/ScriptBinder/MonoManager.cpp
+++ b/ScriptBinder/MonoManager.cpp
@@ -2,6 +2,7 @@
 #ifndef UNUSE_MONO_LIB
 #include "Object_Binding.h"
 #include "Component_Binding.h"
+#include "GameObject_Binding.h"
 #include <cassert>
 #include <sstream>
 #include <iostream>
@@ -156,6 +157,7 @@ void MonoManager::RegisterInternalCalls()
 {
     // 여기에 엔진의 모든 바인딩 등록 함수 호출
     Register_Object_ICalls();
+    Register_GameObject_ICalls();
     // Register_Component_ICalls();
     // Register_Transform_ICalls();
     // ...

--- a/ScriptBinder/MonoManager.h
+++ b/ScriptBinder/MonoManager.h
@@ -1,5 +1,4 @@
 #pragma once
-#define UNUSE_MONO_LIB
 #ifndef UNUSE_MONO_LIB
 #include <DLLAcrossSingleton.h>
 #include <string>

--- a/ScriptBinder/Object_Binding.h
+++ b/ScriptBinder/Object_Binding.h
@@ -1,5 +1,4 @@
 #pragma once
-#define UNUSE_MONO_LIB
 #ifndef UNUSE_MONO_LIB
 
 // Object_Bindings.cpp


### PR DESCRIPTION
## Summary
- add Mono internal calls that expose GameObject lookup, component access, and metadata helpers
- register the GameObject bindings with the Mono manager and extend the C# GameObject wrapper accordingly
- keep the Mono integration disabled on the engine side by defining `UNUSE_MONO_LIB`

## Testing
- not run (Mono integration disabled)

------
https://chatgpt.com/codex/tasks/task_e_6907437097a8832da1688bbe635b30ce