### PR TITLE
Move managed math types into Mathf namespace

### DIFF
--- a/Assembly-CSharp/Assembly-CSharp/Assembly-CSharp/Class/GameObject.cs
+++ b/Assembly-CSharp/Assembly-CSharp/Assembly-CSharp/Class/GameObject.cs
@@ -15,6 +15,9 @@ namespace CreatorEngine
         private static extern IntPtr ICall_GetComponent(IntPtr self, uint typeGuid);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern IntPtr ICall_GetTransform(IntPtr self);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string ICall_GetTag(IntPtr self);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
@@ -79,6 +82,30 @@ namespace CreatorEngine
             var component = new Component();
             component.m_NativePtr = componentPtr;
             return component;
+        }
+
+        private Transform? m_CachedTransform;
+
+        public Transform Transform
+        {
+            get
+            {
+                if (m_CachedTransform == null)
+                {
+                    IntPtr transformPtr = ICall_GetTransform(m_NativePtr);
+                    if (transformPtr == IntPtr.Zero)
+                    {
+                        throw new InvalidOperationException("Native transform pointer is null.");
+                    }
+
+                    m_CachedTransform = new Transform
+                    {
+                        m_NativePtr = transformPtr
+                    };
+                }
+
+                return m_CachedTransform;
+            }
         }
 
         public string Tag

--- a/Assembly-CSharp/Assembly-CSharp/Assembly-CSharp/Class/MathTypes.cs
+++ b/Assembly-CSharp/Assembly-CSharp/Assembly-CSharp/Class/MathTypes.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Mathf
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Vector3
+    {
+        public float X;
+        public float Y;
+        public float Z;
+
+        public Vector3(float x, float y, float z)
+        {
+            X = x;
+            Y = y;
+            Z = z;
+        }
+
+        public override string ToString() => $"({X}, {Y}, {Z})";
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Quaternion
+    {
+        public float X;
+        public float Y;
+        public float Z;
+        public float W;
+
+        public Quaternion(float x, float y, float z, float w)
+        {
+            X = x;
+            Y = y;
+            Z = z;
+            W = w;
+        }
+
+        public override string ToString() => $"({X}, {Y}, {Z}, {W})";
+    }
+}

--- a/Assembly-CSharp/Assembly-CSharp/Assembly-CSharp/Class/Transform.cs
+++ b/Assembly-CSharp/Assembly-CSharp/Assembly-CSharp/Class/Transform.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Runtime.CompilerServices;
+using Mathf;
+
+namespace CreatorEngine
+{
+    public class Transform
+    {
+        internal IntPtr m_NativePtr;
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern Vector3 ICall_GetLocalPosition(IntPtr self);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern void ICall_SetLocalPosition(IntPtr self, Vector3 position);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern Quaternion ICall_GetLocalRotation(IntPtr self);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern void ICall_SetLocalRotation(IntPtr self, Quaternion rotation);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern Vector3 ICall_GetLocalScale(IntPtr self);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern void ICall_SetLocalScale(IntPtr self, Vector3 scale);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern Vector3 ICall_GetWorldPosition(IntPtr self);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern void ICall_SetWorldPosition(IntPtr self, Vector3 position);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern Quaternion ICall_GetWorldRotation(IntPtr self);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern void ICall_SetWorldRotation(IntPtr self, Quaternion rotation);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern Vector3 ICall_GetWorldScale(IntPtr self);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern void ICall_SetWorldScale(IntPtr self, Vector3 scale);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern Vector3 ICall_GetForward(IntPtr self);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern Vector3 ICall_GetRight(IntPtr self);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern Vector3 ICall_GetUp(IntPtr self);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern IntPtr ICall_GetOwner(IntPtr self);
+
+        public Vector3 LocalPosition
+        {
+            get => ICall_GetLocalPosition(m_NativePtr);
+            set => ICall_SetLocalPosition(m_NativePtr, value);
+        }
+
+        public Quaternion LocalRotation
+        {
+            get => ICall_GetLocalRotation(m_NativePtr);
+            set => ICall_SetLocalRotation(m_NativePtr, value);
+        }
+
+        public Vector3 LocalScale
+        {
+            get => ICall_GetLocalScale(m_NativePtr);
+            set => ICall_SetLocalScale(m_NativePtr, value);
+        }
+
+        public Vector3 WorldPosition
+        {
+            get => ICall_GetWorldPosition(m_NativePtr);
+            set => ICall_SetWorldPosition(m_NativePtr, value);
+        }
+
+        public Quaternion WorldRotation
+        {
+            get => ICall_GetWorldRotation(m_NativePtr);
+            set => ICall_SetWorldRotation(m_NativePtr, value);
+        }
+
+        public Vector3 WorldScale
+        {
+            get => ICall_GetWorldScale(m_NativePtr);
+            set => ICall_SetWorldScale(m_NativePtr, value);
+        }
+
+        public Vector3 Forward => ICall_GetForward(m_NativePtr);
+        public Vector3 Right => ICall_GetRight(m_NativePtr);
+        public Vector3 Up => ICall_GetUp(m_NativePtr);
+
+        public GameObject? Owner
+        {
+            get
+            {
+                IntPtr ownerPtr = ICall_GetOwner(m_NativePtr);
+                if (ownerPtr == IntPtr.Zero)
+                {
+                    return null;
+                }
+
+                var gameObject = new GameObject();
+                gameObject.m_NativePtr = ownerPtr;
+                return gameObject;
+            }
+        }
+    }
+}

--- a/ScriptBinder/GameObject_Binding.h
+++ b/ScriptBinder/GameObject_Binding.h
@@ -75,6 +75,15 @@ namespace
             return 0;
         }
 
+        static intptr_t ICall_GameObject_GetTransform(MonoObject* _this, intptr_t nativePtr) noexcept
+        {
+            if (auto* self = FromIntPtr<GameObject>(_this, nativePtr))
+            {
+                return reinterpret_cast<intptr_t>(&self->m_transform);
+            }
+            return 0;
+        }
+
         static MonoString* ICall_GameObject_GetTag(MonoObject* _this, intptr_t nativePtr)
         {
             if (auto* self = FromIntPtr<GameObject>(_this, nativePtr))
@@ -135,6 +144,7 @@ inline void Register_GameObject_ICalls()
     mono_add_internal_call("CreatorEngine.GameObject::ICall_Find", (const void*)ICall_GameObject_Find);
     mono_add_internal_call("CreatorEngine.GameObject::ICall_FindIndex", (const void*)ICall_GameObject_FindIndex);
     mono_add_internal_call("CreatorEngine.GameObject::ICall_GetComponent", (const void*)ICall_GameObject_GetComponent);
+    mono_add_internal_call("CreatorEngine.GameObject::ICall_GetTransform", (const void*)ICall_GameObject_GetTransform);
     mono_add_internal_call("CreatorEngine.GameObject::ICall_GetTag", (const void*)ICall_GameObject_GetTag);
     mono_add_internal_call("CreatorEngine.GameObject::ICall_SetTag", (const void*)ICall_GameObject_SetTag);
     mono_add_internal_call("CreatorEngine.GameObject::ICall_GetLayer", (const void*)ICall_GameObject_GetLayer);

--- a/ScriptBinder/MonoManager.cpp
+++ b/ScriptBinder/MonoManager.cpp
@@ -3,6 +3,7 @@
 #include "Object_Binding.h"
 #include "Component_Binding.h"
 #include "GameObject_Binding.h"
+#include "Transform_Binding.h"
 #include <cassert>
 #include <sstream>
 #include <iostream>
@@ -159,7 +160,7 @@ void MonoManager::RegisterInternalCalls()
     Register_Object_ICalls();
     Register_GameObject_ICalls();
     // Register_Component_ICalls();
-    // Register_Transform_ICalls();
+    Register_Transform_ICalls();
     // ...
 }
 

--- a/ScriptBinder/Transform_Binding.h
+++ b/ScriptBinder/Transform_Binding.h
@@ -1,0 +1,186 @@
+#pragma once
+#ifndef UNUSE_MONO_LIB
+
+#include "FormIntPtr.h"
+#include "Transform.h"
+
+#include <mono/metadata/object.h>
+
+namespace
+{
+    inline Mathf::Vector3 ToVector3(const Mathf::Vector4& value) noexcept
+    {
+        return { value.x, value.y, value.z };
+    }
+
+    inline Mathf::Quaternion ToQuaternion(const Mathf::Vector4& value) noexcept
+    {
+        return { value.x, value.y, value.z, value.w };
+    }
+
+    extern "C"
+    {
+        static Mathf::Vector3 ICall_Transform_GetLocalPosition(MonoObject* _this, intptr_t nativePtr) noexcept
+        {
+            if (auto* self = FromIntPtr<Transform>(_this, nativePtr))
+            {
+                return ToVector3(self->position);
+            }
+            return {};
+        }
+
+        static void ICall_Transform_SetLocalPosition(MonoObject* _this, intptr_t nativePtr, Mathf::Vector3 position) noexcept
+        {
+            if (auto* self = FromIntPtr<Transform>(_this, nativePtr))
+            {
+                self->SetPosition(position);
+            }
+        }
+
+        static Mathf::Quaternion ICall_Transform_GetLocalRotation(MonoObject* _this, intptr_t nativePtr) noexcept
+        {
+            if (auto* self = FromIntPtr<Transform>(_this, nativePtr))
+            {
+                return ToQuaternion(self->rotation);
+            }
+            return {};
+        }
+
+        static void ICall_Transform_SetLocalRotation(MonoObject* _this, intptr_t nativePtr, Mathf::Quaternion rotation) noexcept
+        {
+            if (auto* self = FromIntPtr<Transform>(_this, nativePtr))
+            {
+                self->SetRotation(rotation);
+            }
+        }
+
+        static Mathf::Vector3 ICall_Transform_GetLocalScale(MonoObject* _this, intptr_t nativePtr) noexcept
+        {
+            if (auto* self = FromIntPtr<Transform>(_this, nativePtr))
+            {
+                return ToVector3(self->scale);
+            }
+            return {};
+        }
+
+        static void ICall_Transform_SetLocalScale(MonoObject* _this, intptr_t nativePtr, Mathf::Vector3 scale) noexcept
+        {
+            if (auto* self = FromIntPtr<Transform>(_this, nativePtr))
+            {
+                self->SetScale(scale);
+            }
+        }
+
+        static Mathf::Vector3 ICall_Transform_GetWorldPosition(MonoObject* _this, intptr_t nativePtr) noexcept
+        {
+            if (auto* self = FromIntPtr<Transform>(_this, nativePtr))
+            {
+                return { self->GetWorldPosition() };
+            }
+            return {};
+        }
+
+        static void ICall_Transform_SetWorldPosition(MonoObject* _this, intptr_t nativePtr, Mathf::Vector3 position) noexcept
+        {
+            if (auto* self = FromIntPtr<Transform>(_this, nativePtr))
+            {
+                self->SetWorldPosition(position);
+            }
+        }
+
+        static Mathf::Quaternion ICall_Transform_GetWorldRotation(MonoObject* _this, intptr_t nativePtr) noexcept
+        {
+            if (auto* self = FromIntPtr<Transform>(_this, nativePtr))
+            {
+                return { self->GetWorldQuaternion() };
+            }
+            return {};
+        }
+
+        static void ICall_Transform_SetWorldRotation(MonoObject* _this, intptr_t nativePtr, Mathf::Quaternion rotation) noexcept
+        {
+            if (auto* self = FromIntPtr<Transform>(_this, nativePtr))
+            {
+                self->SetWorldRotation(rotation);
+            }
+        }
+
+        static Mathf::Vector3 ICall_Transform_GetWorldScale(MonoObject* _this, intptr_t nativePtr) noexcept
+        {
+            if (auto* self = FromIntPtr<Transform>(_this, nativePtr))
+            {
+                return { self->GetWorldScale() };
+            }
+            return {};
+        }
+
+        static void ICall_Transform_SetWorldScale(MonoObject* _this, intptr_t nativePtr, Mathf::Vector3 scale) noexcept
+        {
+            if (auto* self = FromIntPtr<Transform>(_this, nativePtr))
+            {
+                self->SetWorldScale(scale);
+            }
+        }
+
+        static Mathf::Vector3 ICall_Transform_GetForward(MonoObject* _this, intptr_t nativePtr) noexcept
+        {
+            if (auto* self = FromIntPtr<Transform>(_this, nativePtr))
+            {
+                return self->GetForward();
+            }
+            return {};
+        }
+
+        static Mathf::Vector3 ICall_Transform_GetRight(MonoObject* _this, intptr_t nativePtr) noexcept
+        {
+            if (auto* self = FromIntPtr<Transform>(_this, nativePtr))
+            {
+                return self->GetRight();
+            }
+            return {};
+        }
+
+        static Mathf::Vector3 ICall_Transform_GetUp(MonoObject* _this, intptr_t nativePtr) noexcept
+        {
+            if (auto* self = FromIntPtr<Transform>(_this, nativePtr))
+            {
+                return self->GetUp();
+            }
+            return {};
+        }
+
+        static intptr_t ICall_Transform_GetOwner(MonoObject* _this, intptr_t nativePtr) noexcept
+        {
+            if (auto* self = FromIntPtr<Transform>(_this, nativePtr))
+            {
+                if (auto* owner = self->GetOwner())
+                {
+                    return reinterpret_cast<intptr_t>(owner);
+                }
+            }
+            return 0;
+        }
+    }
+}
+
+inline void Register_Transform_ICalls()
+{
+    mono_add_internal_call("CreatorEngine.Transform::ICall_GetLocalPosition", (const void*)ICall_Transform_GetLocalPosition);
+    mono_add_internal_call("CreatorEngine.Transform::ICall_SetLocalPosition", (const void*)ICall_Transform_SetLocalPosition);
+    mono_add_internal_call("CreatorEngine.Transform::ICall_GetLocalRotation", (const void*)ICall_Transform_GetLocalRotation);
+    mono_add_internal_call("CreatorEngine.Transform::ICall_SetLocalRotation", (const void*)ICall_Transform_SetLocalRotation);
+    mono_add_internal_call("CreatorEngine.Transform::ICall_GetLocalScale", (const void*)ICall_Transform_GetLocalScale);
+    mono_add_internal_call("CreatorEngine.Transform::ICall_SetLocalScale", (const void*)ICall_Transform_SetLocalScale);
+    mono_add_internal_call("CreatorEngine.Transform::ICall_GetWorldPosition", (const void*)ICall_Transform_GetWorldPosition);
+    mono_add_internal_call("CreatorEngine.Transform::ICall_SetWorldPosition", (const void*)ICall_Transform_SetWorldPosition);
+    mono_add_internal_call("CreatorEngine.Transform::ICall_GetWorldRotation", (const void*)ICall_Transform_GetWorldRotation);
+    mono_add_internal_call("CreatorEngine.Transform::ICall_SetWorldRotation", (const void*)ICall_Transform_SetWorldRotation);
+    mono_add_internal_call("CreatorEngine.Transform::ICall_GetWorldScale", (const void*)ICall_Transform_GetWorldScale);
+    mono_add_internal_call("CreatorEngine.Transform::ICall_SetWorldScale", (const void*)ICall_Transform_SetWorldScale);
+    mono_add_internal_call("CreatorEngine.Transform::ICall_GetForward", (const void*)ICall_Transform_GetForward);
+    mono_add_internal_call("CreatorEngine.Transform::ICall_GetRight", (const void*)ICall_Transform_GetRight);
+    mono_add_internal_call("CreatorEngine.Transform::ICall_GetUp", (const void*)ICall_Transform_GetUp);
+    mono_add_internal_call("CreatorEngine.Transform::ICall_GetOwner", (const void*)ICall_Transform_GetOwner);
+}
+
+#endif // !UNUSE_MONO_LIB


### PR DESCRIPTION
## Summary
- move the managed Vector3 and Quaternion structs under the Mathf namespace
- update the managed Transform wrapper to import the Mathf namespace for interop types

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_690746f8b438832d8f60416bc0a3652f