### PR TITLE
Add RectTransform bindings for Mono integration

### DIFF
--- a/Assembly-CSharp/Assembly-CSharp/Assembly-CSharp/Class/GameObject.cs
+++ b/Assembly-CSharp/Assembly-CSharp/Assembly-CSharp/Class/GameObject.cs
@@ -85,6 +85,7 @@ namespace CreatorEngine
         }
 
         private Transform? m_CachedTransform;
+        private RectTransform? m_CachedRectTransform;
 
         public Transform Transform
         {
@@ -105,6 +106,19 @@ namespace CreatorEngine
                 }
 
                 return m_CachedTransform;
+            }
+        }
+
+        public RectTransform? RectTransform
+        {
+            get
+            {
+                if (m_CachedRectTransform == null || m_CachedRectTransform.m_NativePtr == IntPtr.Zero)
+                {
+                    m_CachedRectTransform = RectTransform.Get(this);
+                }
+
+                return m_CachedRectTransform;
             }
         }
 

--- a/Assembly-CSharp/Assembly-CSharp/Assembly-CSharp/Class/MathTypes.cs
+++ b/Assembly-CSharp/Assembly-CSharp/Assembly-CSharp/Class/MathTypes.cs
@@ -4,6 +4,21 @@ using System.Runtime.InteropServices;
 namespace Mathf
 {
     [StructLayout(LayoutKind.Sequential)]
+    public struct Vector2
+    {
+        public float X;
+        public float Y;
+
+        public Vector2(float x, float y)
+        {
+            X = x;
+            Y = y;
+        }
+
+        public override string ToString() => $"({X}, {Y})";
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
     public struct Vector3
     {
         public float X;
@@ -37,5 +52,24 @@ namespace Mathf
         }
 
         public override string ToString() => $"({X}, {Y}, {Z}, {W})";
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Rect
+    {
+        public float X;
+        public float Y;
+        public float Width;
+        public float Height;
+
+        public Rect(float x, float y, float width, float height)
+        {
+            X = x;
+            Y = y;
+            Width = width;
+            Height = height;
+        }
+
+        public override string ToString() => $"({X}, {Y}, {Width}, {Height})";
     }
 }

--- a/Assembly-CSharp/Assembly-CSharp/Assembly-CSharp/Class/RectTransform.cs
+++ b/Assembly-CSharp/Assembly-CSharp/Assembly-CSharp/Class/RectTransform.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Runtime.CompilerServices;
+using Mathf;
+
+namespace CreatorEngine
+{
+    public enum AnchorPreset
+    {
+        TopLeft, TopCenter, TopRight,
+        MiddleLeft, MiddleCenter, MiddleRight,
+        BottomLeft, BottomCenter, BottomRight,
+        StretchLeft, StretchCenter, StretchRight,
+        StretchTop, StretchMiddle, StretchBottom,
+        StretchAll
+    }
+
+    public class RectTransform : Component
+    {
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern Vector2 ICall_GetAnchorMin(IntPtr self);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern void ICall_SetAnchorMin(IntPtr self, Vector2 anchorMin);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern Vector2 ICall_GetAnchorMax(IntPtr self);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern void ICall_SetAnchorMax(IntPtr self, Vector2 anchorMax);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern Vector2 ICall_GetAnchoredPosition(IntPtr self);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern void ICall_SetAnchoredPosition(IntPtr self, Vector2 position);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern Vector2 ICall_GetSizeDelta(IntPtr self);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern void ICall_SetSizeDelta(IntPtr self, Vector2 sizeDelta);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern Vector2 ICall_GetPivot(IntPtr self);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern void ICall_SetPivot(IntPtr self, Vector2 pivot);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern Rect ICall_GetWorldRect(IntPtr self);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern void ICall_SetAnchorPreset(IntPtr self, AnchorPreset preset);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern void ICall_SetAnchorsPivotKeepWorld(IntPtr self, Vector2 newAnchorMin, Vector2 newAnchorMax, Vector2 newPivot, Rect parentRect);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern void ICall_SetParentKeepWorldPosition(IntPtr self, IntPtr parentPtr);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern bool ICall_IsDirty(IntPtr self);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern ulong ICall_GetTypeID();
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern IntPtr ICall_GetFromGameObject(IntPtr gameObjectPtr);
+
+        public Vector2 AnchorMin
+        {
+            get => ICall_GetAnchorMin(m_NativePtr);
+            set => ICall_SetAnchorMin(m_NativePtr, value);
+        }
+
+        public Vector2 AnchorMax
+        {
+            get => ICall_GetAnchorMax(m_NativePtr);
+            set => ICall_SetAnchorMax(m_NativePtr, value);
+        }
+
+        public Vector2 AnchoredPosition
+        {
+            get => ICall_GetAnchoredPosition(m_NativePtr);
+            set => ICall_SetAnchoredPosition(m_NativePtr, value);
+        }
+
+        public Vector2 SizeDelta
+        {
+            get => ICall_GetSizeDelta(m_NativePtr);
+            set => ICall_SetSizeDelta(m_NativePtr, value);
+        }
+
+        public Vector2 Pivot
+        {
+            get => ICall_GetPivot(m_NativePtr);
+            set => ICall_SetPivot(m_NativePtr, value);
+        }
+
+        public Rect WorldRect => ICall_GetWorldRect(m_NativePtr);
+
+        public bool IsDirty => ICall_IsDirty(m_NativePtr);
+
+        public void SetAnchorPreset(AnchorPreset preset) => ICall_SetAnchorPreset(m_NativePtr, preset);
+
+        public void SetAnchorsPivotKeepWorld(Vector2 anchorMin, Vector2 anchorMax, Vector2 pivot, Rect parentRect)
+            => ICall_SetAnchorsPivotKeepWorld(m_NativePtr, anchorMin, anchorMax, pivot, parentRect);
+
+        public void SetParentKeepWorldPosition(GameObject? newParent)
+            => ICall_SetParentKeepWorldPosition(m_NativePtr, newParent?.m_NativePtr ?? IntPtr.Zero);
+
+        private static readonly ulong s_ComponentTypeId = ICall_GetTypeID();
+
+        public static ulong ComponentTypeId => s_ComponentTypeId;
+
+        internal static RectTransform? CreateFromNative(IntPtr nativePtr)
+        {
+            if (nativePtr == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            return new RectTransform
+            {
+                m_NativePtr = nativePtr
+            };
+        }
+
+        public static RectTransform? Get(GameObject? gameObject)
+        {
+            if (gameObject == null)
+            {
+                return null;
+            }
+
+            IntPtr rectPtr = ICall_GetFromGameObject(gameObject.m_NativePtr);
+            return CreateFromNative(rectPtr);
+        }
+
+        public static RectTransform? FromComponent(Component? component)
+        {
+            if (component == null || component.TypeID != ComponentTypeId)
+            {
+                return null;
+            }
+
+            return new RectTransform
+            {
+                m_NativePtr = component.m_NativePtr
+            };
+        }
+    }
+}

--- a/ScriptBinder/MonoManager.cpp
+++ b/ScriptBinder/MonoManager.cpp
@@ -4,6 +4,7 @@
 #include "Component_Binding.h"
 #include "GameObject_Binding.h"
 #include "Transform_Binding.h"
+#include "RectTransform_Binding.h"
 #include <cassert>
 #include <sstream>
 #include <iostream>
@@ -161,6 +162,7 @@ void MonoManager::RegisterInternalCalls()
     Register_GameObject_ICalls();
     // Register_Component_ICalls();
     Register_Transform_ICalls();
+    Register_RectTransform_ICalls();
     // ...
 }
 

--- a/ScriptBinder/RectTransform_Binding.h
+++ b/ScriptBinder/RectTransform_Binding.h
@@ -1,0 +1,199 @@
+#pragma once
+#ifndef UNUSE_MONO_LIB
+
+#include "FormIntPtr.h"
+#include "RectTransformComponent.h"
+#include "GameObject.h"
+#include "TypeTrait.h"
+
+#include <mono/metadata/object.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <type_traits>
+
+namespace
+{
+    constexpr AnchorPreset ClampAnchorPreset(int32_t value) noexcept
+    {
+        using Underlying = std::underlying_type_t<AnchorPreset>;
+        const auto clamped = std::clamp(static_cast<Underlying>(value), static_cast<Underlying>(AnchorPreset::TopLeft), static_cast<Underlying>(AnchorPreset::StretchAll));
+        return static_cast<AnchorPreset>(clamped);
+    }
+
+    extern "C"
+    {
+        static Mathf::Vector2 ICall_RectTransform_GetAnchorMin(MonoObject* _this, intptr_t nativePtr) noexcept
+        {
+            if (auto* self = FromIntPtr<RectTransformComponent>(_this, nativePtr))
+            {
+                return self->GetAnchorMin();
+            }
+            return {};
+        }
+
+        static void ICall_RectTransform_SetAnchorMin(MonoObject* _this, intptr_t nativePtr, Mathf::Vector2 anchorMin) noexcept
+        {
+            if (auto* self = FromIntPtr<RectTransformComponent>(_this, nativePtr))
+            {
+                self->SetAnchorMin(anchorMin);
+            }
+        }
+
+        static Mathf::Vector2 ICall_RectTransform_GetAnchorMax(MonoObject* _this, intptr_t nativePtr) noexcept
+        {
+            if (auto* self = FromIntPtr<RectTransformComponent>(_this, nativePtr))
+            {
+                return self->GetAnchorMax();
+            }
+            return {};
+        }
+
+        static void ICall_RectTransform_SetAnchorMax(MonoObject* _this, intptr_t nativePtr, Mathf::Vector2 anchorMax) noexcept
+        {
+            if (auto* self = FromIntPtr<RectTransformComponent>(_this, nativePtr))
+            {
+                self->SetAnchorMax(anchorMax);
+            }
+        }
+
+        static Mathf::Vector2 ICall_RectTransform_GetAnchoredPosition(MonoObject* _this, intptr_t nativePtr) noexcept
+        {
+            if (auto* self = FromIntPtr<RectTransformComponent>(_this, nativePtr))
+            {
+                return self->GetAnchoredPosition();
+            }
+            return {};
+        }
+
+        static void ICall_RectTransform_SetAnchoredPosition(MonoObject* _this, intptr_t nativePtr, Mathf::Vector2 anchoredPosition) noexcept
+        {
+            if (auto* self = FromIntPtr<RectTransformComponent>(_this, nativePtr))
+            {
+                self->SetAnchoredPosition(anchoredPosition);
+            }
+        }
+
+        static Mathf::Vector2 ICall_RectTransform_GetSizeDelta(MonoObject* _this, intptr_t nativePtr) noexcept
+        {
+            if (auto* self = FromIntPtr<RectTransformComponent>(_this, nativePtr))
+            {
+                return self->GetSizeDelta();
+            }
+            return {};
+        }
+
+        static void ICall_RectTransform_SetSizeDelta(MonoObject* _this, intptr_t nativePtr, Mathf::Vector2 sizeDelta) noexcept
+        {
+            if (auto* self = FromIntPtr<RectTransformComponent>(_this, nativePtr))
+            {
+                self->SetSizeDelta(sizeDelta);
+            }
+        }
+
+        static Mathf::Vector2 ICall_RectTransform_GetPivot(MonoObject* _this, intptr_t nativePtr) noexcept
+        {
+            if (auto* self = FromIntPtr<RectTransformComponent>(_this, nativePtr))
+            {
+                return self->GetPivot();
+            }
+            return {};
+        }
+
+        static void ICall_RectTransform_SetPivot(MonoObject* _this, intptr_t nativePtr, Mathf::Vector2 pivot) noexcept
+        {
+            if (auto* self = FromIntPtr<RectTransformComponent>(_this, nativePtr))
+            {
+                self->SetPivot(pivot);
+            }
+        }
+
+        static Mathf::Rect ICall_RectTransform_GetWorldRect(MonoObject* _this, intptr_t nativePtr) noexcept
+        {
+            if (auto* self = FromIntPtr<RectTransformComponent>(_this, nativePtr))
+            {
+                return self->GetWorldRect();
+            }
+            return {};
+        }
+
+        static void ICall_RectTransform_SetAnchorPreset(MonoObject* _this, intptr_t nativePtr, int32_t preset) noexcept
+        {
+            if (auto* self = FromIntPtr<RectTransformComponent>(_this, nativePtr))
+            {
+                self->SetAnchorPreset(ClampAnchorPreset(preset));
+            }
+        }
+
+        static void ICall_RectTransform_SetAnchorsPivotKeepWorld(MonoObject* _this,
+            intptr_t nativePtr,
+            Mathf::Vector2 newAnchorMin,
+            Mathf::Vector2 newAnchorMax,
+            Mathf::Vector2 newPivot,
+            Mathf::Rect newParentRect) noexcept
+        {
+            if (auto* self = FromIntPtr<RectTransformComponent>(_this, nativePtr))
+            {
+                self->SetAnchorsPivotKeepWorld(newAnchorMin, newAnchorMax, newPivot, newParentRect);
+            }
+        }
+
+        static void ICall_RectTransform_SetParentKeepWorldPosition(MonoObject* _this, intptr_t nativePtr, intptr_t parentPtr) noexcept
+        {
+            if (auto* self = FromIntPtr<RectTransformComponent>(_this, nativePtr))
+            {
+                auto* parent = reinterpret_cast<GameObject*>(parentPtr);
+                self->SetParentKeepWorldPosition(parent);
+            }
+        }
+
+        static mono_bool ICall_RectTransform_IsDirty(MonoObject* _this, intptr_t nativePtr) noexcept
+        {
+            if (auto* self = FromIntPtr<RectTransformComponent>(_this, nativePtr))
+            {
+                return self->IsDirty() ? 1 : 0;
+            }
+            return 0;
+        }
+
+        static uint64_t ICall_RectTransform_GetTypeID() noexcept
+        {
+            return static_cast<uint64_t>(type_guid(RectTransformComponent));
+        }
+
+        static intptr_t ICall_RectTransform_GetFromGameObject(intptr_t gameObjectPtr) noexcept
+        {
+            if (auto* gameObject = reinterpret_cast<GameObject*>(gameObjectPtr))
+            {
+                if (auto* rect = gameObject->GetComponent<RectTransformComponent>())
+                {
+                    return reinterpret_cast<intptr_t>(rect);
+                }
+            }
+            return 0;
+        }
+    }
+}
+
+inline void Register_RectTransform_ICalls()
+{
+    mono_add_internal_call("CreatorEngine.RectTransform::ICall_GetAnchorMin", (const void*)ICall_RectTransform_GetAnchorMin);
+    mono_add_internal_call("CreatorEngine.RectTransform::ICall_SetAnchorMin", (const void*)ICall_RectTransform_SetAnchorMin);
+    mono_add_internal_call("CreatorEngine.RectTransform::ICall_GetAnchorMax", (const void*)ICall_RectTransform_GetAnchorMax);
+    mono_add_internal_call("CreatorEngine.RectTransform::ICall_SetAnchorMax", (const void*)ICall_RectTransform_SetAnchorMax);
+    mono_add_internal_call("CreatorEngine.RectTransform::ICall_GetAnchoredPosition", (const void*)ICall_RectTransform_GetAnchoredPosition);
+    mono_add_internal_call("CreatorEngine.RectTransform::ICall_SetAnchoredPosition", (const void*)ICall_RectTransform_SetAnchoredPosition);
+    mono_add_internal_call("CreatorEngine.RectTransform::ICall_GetSizeDelta", (const void*)ICall_RectTransform_GetSizeDelta);
+    mono_add_internal_call("CreatorEngine.RectTransform::ICall_SetSizeDelta", (const void*)ICall_RectTransform_SetSizeDelta);
+    mono_add_internal_call("CreatorEngine.RectTransform::ICall_GetPivot", (const void*)ICall_RectTransform_GetPivot);
+    mono_add_internal_call("CreatorEngine.RectTransform::ICall_SetPivot", (const void*)ICall_RectTransform_SetPivot);
+    mono_add_internal_call("CreatorEngine.RectTransform::ICall_GetWorldRect", (const void*)ICall_RectTransform_GetWorldRect);
+    mono_add_internal_call("CreatorEngine.RectTransform::ICall_SetAnchorPreset", (const void*)ICall_RectTransform_SetAnchorPreset);
+    mono_add_internal_call("CreatorEngine.RectTransform::ICall_SetAnchorsPivotKeepWorld", (const void*)ICall_RectTransform_SetAnchorsPivotKeepWorld);
+    mono_add_internal_call("CreatorEngine.RectTransform::ICall_SetParentKeepWorldPosition", (const void*)ICall_RectTransform_SetParentKeepWorldPosition);
+    mono_add_internal_call("CreatorEngine.RectTransform::ICall_IsDirty", (const void*)ICall_RectTransform_IsDirty);
+    mono_add_internal_call("CreatorEngine.RectTransform::ICall_GetTypeID", (const void*)ICall_RectTransform_GetTypeID);
+    mono_add_internal_call("CreatorEngine.RectTransform::ICall_GetFromGameObject", (const void*)ICall_RectTransform_GetFromGameObject);
+}
+
+#endif // !UNUSE_MONO_LIB

--- a/ScriptBinder/ScriptBinder.vcxproj
+++ b/ScriptBinder/ScriptBinder.vcxproj
@@ -314,6 +314,7 @@
     <ClInclude Include="Object_Binding.h" />
     <ClInclude Include="Component_Binding.h" />
     <ClInclude Include="RectTransformComponent.h" />
+    <ClInclude Include="RectTransform_Binding.h" />
     <ClInclude Include="CurvePoint.h" />
     <ClInclude Include="ScriptStringModule.h" />
     <ClInclude Include="SoundComponent.h" />

--- a/ScriptBinder/ScriptBinder.vcxproj.filters
+++ b/ScriptBinder/ScriptBinder.vcxproj.filters
@@ -688,6 +688,9 @@
     <ClInclude Include="GameObject_Binding.h">
       <Filter>Managers\HotLoadSystem\MonoLibSystem\Test</Filter>
     </ClInclude>
+    <ClInclude Include="RectTransform_Binding.h">
+      <Filter>Managers\HotLoadSystem\MonoLibSystem\Test</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="GameObject.inl">


### PR DESCRIPTION
## Summary
- add native RectTransform internal calls and register them with the Mono manager
- expose a managed RectTransform wrapper with supporting math structs and GameObject accessors
- update project metadata to include the new bindings and managed types

## Testing
- dotnet build Assembly-CSharp/Assembly-CSharp/Assembly-CSharp/Assembly-CSharp.csproj *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_69074a237ed0832dae6282c76e51a05e