### PR TITLE
Add MonoManager event binding for C# scripts

### DIFF
--- a/ScriptBinder/CSharpScriptComponent.h
+++ b/ScriptBinder/CSharpScriptComponent.h
@@ -8,6 +8,7 @@
 
 #include <cstdint>
 #include "MonoBehaviorRecord.h"
+#include "MonoManager.h"
 
 #include <atomic>
 #include <mutex>
@@ -48,6 +49,10 @@ public:
         if (m_monoInstance != nullptr)
         {
             m_handle = RegisterManagedInstance(m_monoInstance);
+            if (auto* monoManager = MonoManager::GetInstance(); monoManager != nullptr)
+            {
+                monoManager->BindScriptEvents(this);
+            }
         }
     }
 
@@ -98,6 +103,11 @@ private:
     {
         if (m_handle != 0)
         {
+            if (auto* monoManager = MonoManager::GetInstance(); monoManager != nullptr)
+            {
+                monoManager->UnbindScriptEvents(this);
+            }
+
             UnregisterManagedInstance(m_handle);
             m_handle = 0;
         }

--- a/ScriptBinder/MonoBehaviorRecord.h
+++ b/ScriptBinder/MonoBehaviorRecord.h
@@ -6,10 +6,23 @@
 
 using MonoBehaviorHandle = uint32_t;
 
+enum class MonoBehaviorEvent
+{
+    Awake,
+    OnEnable,
+    Start,
+    FixedUpdate,
+    Update,
+    LateUpdate,
+    OnDisable,
+    OnDestroy,
+};
+
 struct MethodHandlePair
 {
     MonoMethod*          method{ nullptr };
     Core::DelegateHandle handle{};
+    MonoBehaviorEvent    event{ MonoBehaviorEvent::Awake };
 };
 
 // C# MonoBehavior 타입별 메서드 포인터 정보
@@ -24,9 +37,9 @@ struct MonoBehaviorInfo
 
 struct MonoBehaviorRecord
 {
-    MonoBehaviorHandle              id{};
-    MonoObject*                     instance{ nullptr };
-    std::vector<MethodHandlePair>   events;
+    MonoBehaviorHandle            id{};
+    MonoObject*                   instance{ nullptr };
+    std::vector<MethodHandlePair> events;
 };
 
 #endif // UNUSE_MONO_LIB

--- a/ScriptBinder/MonoManager.cpp
+++ b/ScriptBinder/MonoManager.cpp
@@ -5,9 +5,19 @@
 #include "GameObject_Binding.h"
 #include "Transform_Binding.h"
 #include "RectTransform_Binding.h"
+#include "CSharpScriptComponent.h"
+#include "GameObject.h"
+#include "Scene.h"
+#include "DataSystem.h"
 #include <cassert>
 #include <sstream>
 #include <iostream>
+#include <array>
+#include <string_view>
+#include <optional>
+#include <filesystem>
+#include <utility>
+#include <yaml-cpp/yaml.h>
 #include <mono/metadata/mono-gc.h>
 #include <mono/metadata/threads.h>
 
@@ -298,5 +308,318 @@ MonoImage* MonoManager::GetImage(const std::string& assemblyName) const
     auto it = m_assemblies.find(assemblyName);
     if (it == m_assemblies.end()) return nullptr;
     return it->second.image;
+}
+
+namespace
+{
+    using EventMapping = std::pair<std::string_view, MonoBehaviorEvent>;
+    constexpr std::array<EventMapping, 8> kSupportedEvents{
+        EventMapping{ "Awake", MonoBehaviorEvent::Awake },
+        EventMapping{ "OnEnable", MonoBehaviorEvent::OnEnable },
+        EventMapping{ "Start", MonoBehaviorEvent::Start },
+        EventMapping{ "FixedUpdate", MonoBehaviorEvent::FixedUpdate },
+        EventMapping{ "Update", MonoBehaviorEvent::Update },
+        EventMapping{ "LateUpdate", MonoBehaviorEvent::LateUpdate },
+        EventMapping{ "OnDisable", MonoBehaviorEvent::OnDisable },
+        EventMapping{ "OnDestroy", MonoBehaviorEvent::OnDestroy },
+    };
+}
+
+std::optional<MonoBehaviorEvent> MonoManager::ToBehaviorEvent(std::string_view name)
+{
+    for (const auto& [eventName, eventType] : kSupportedEvents)
+    {
+        if (eventName == name)
+        {
+            return eventType;
+        }
+    }
+    return std::nullopt;
+}
+
+int MonoManager::ExpectedParameterCount(MonoBehaviorEvent eventType)
+{
+    switch (eventType)
+    {
+    case MonoBehaviorEvent::FixedUpdate:
+    case MonoBehaviorEvent::Update:
+    case MonoBehaviorEvent::LateUpdate:
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+void MonoManager::InvokeMonoBehavior(MonoBehaviorHandle handle, MonoMethod* method, void** args, std::string_view eventName) const
+{
+    if (!method)
+    {
+        return;
+    }
+
+    MonoObject* instance = CSharpScriptComponent::ResolveMonoInstance(handle);
+    if (!instance)
+    {
+        return;
+    }
+
+    MonoObject* exception = nullptr;
+    mono_runtime_invoke(method, instance, args, &exception);
+    if (exception)
+    {
+        std::cerr << "[Mono.Exception] " << eventName << ": " << FormatException(exception) << '\n';
+    }
+}
+
+Core::DelegateHandle MonoManager::RegisterEventHandler(Scene* scene,
+    MonoBehaviorHandle handle,
+    MonoMethod* method,
+    MonoBehaviorEvent eventType,
+    std::string_view eventName) const
+{
+    if (!scene || !method)
+    {
+        return {};
+    }
+
+    switch (eventType)
+    {
+    case MonoBehaviorEvent::Awake:
+        return scene->AwakeEvent.AddLambda([this, handle, method, label = std::string(eventName)]()
+        {
+            InvokeMonoBehavior(handle, method, nullptr, label);
+        });
+    case MonoBehaviorEvent::OnEnable:
+        return scene->OnEnableEvent.AddLambda([this, handle, method, label = std::string(eventName)]()
+        {
+            InvokeMonoBehavior(handle, method, nullptr, label);
+        });
+    case MonoBehaviorEvent::Start:
+        return scene->StartEvent.AddLambda([this, handle, method, label = std::string(eventName)]()
+        {
+            InvokeMonoBehavior(handle, method, nullptr, label);
+        });
+    case MonoBehaviorEvent::FixedUpdate:
+        return scene->FixedUpdateEvent.AddLambda([this, handle, method, label = std::string(eventName)](float fixedTick)
+        {
+            void* args[]{ &fixedTick };
+            InvokeMonoBehavior(handle, method, args, label);
+        });
+    case MonoBehaviorEvent::Update:
+        return scene->UpdateEvent.AddLambda([this, handle, method, label = std::string(eventName)](float delta)
+        {
+            void* args[]{ &delta };
+            InvokeMonoBehavior(handle, method, args, label);
+        });
+    case MonoBehaviorEvent::LateUpdate:
+        return scene->LateUpdateEvent.AddLambda([this, handle, method, label = std::string(eventName)](float delta)
+        {
+            void* args[]{ &delta };
+            InvokeMonoBehavior(handle, method, args, label);
+        });
+    case MonoBehaviorEvent::OnDisable:
+        return scene->OnDisableEvent.AddLambda([this, handle, method, label = std::string(eventName)]()
+        {
+            InvokeMonoBehavior(handle, method, nullptr, label);
+        });
+    case MonoBehaviorEvent::OnDestroy:
+        return scene->OnDestroyEvent.AddLambda([this, handle, method, label = std::string(eventName)]()
+        {
+            InvokeMonoBehavior(handle, method, nullptr, label);
+        });
+    }
+
+    return {};
+}
+
+std::optional<std::vector<std::string>> MonoManager::LoadEventList(const CSharpScriptComponent* component) const
+{
+    if (!component)
+    {
+        return std::nullopt;
+    }
+
+    DataSystem* dataSystem = DataSystem::GetInstance();
+    if (!dataSystem)
+    {
+        return std::nullopt;
+    }
+
+    const auto scriptPath = dataSystem->GetFilePath(component->GetScriptGuid());
+    if (scriptPath.empty())
+    {
+        return std::nullopt;
+    }
+
+    auto metaPath = scriptPath;
+    metaPath += ".meta";
+    if (!std::filesystem::exists(metaPath))
+    {
+        return std::nullopt;
+    }
+
+    YAML::Node scriptNode = YAML::LoadFile(metaPath.string());
+    const YAML::Node eventsNode = scriptNode["eventRegisterSetting"];
+    if (!eventsNode || !eventsNode.IsSequence())
+    {
+        return std::nullopt;
+    }
+
+    std::vector<std::string> events;
+    events.reserve(eventsNode.size());
+    for (const auto& node : eventsNode)
+    {
+        if (!node.IsScalar())
+        {
+            continue;
+        }
+        events.emplace_back(node.as<std::string>());
+    }
+
+    if (events.empty())
+    {
+        return std::nullopt;
+    }
+
+    return events;
+}
+
+void MonoManager::BindScriptEvents(CSharpScriptComponent* component)
+{
+    if (!component || !component->HasManagedInstance())
+    {
+        return;
+    }
+
+    UnbindScriptEvents(component);
+
+    GameObject* owner = component->GetOwner();
+    if (!owner)
+    {
+        return;
+    }
+
+    Scene* scene = owner->GetScene();
+    if (!scene)
+    {
+        return;
+    }
+
+    auto eventsOpt = LoadEventList(component);
+    if (!eventsOpt)
+    {
+        return;
+    }
+
+    MonoObject* instance = component->GetMonoInstance();
+    if (!instance)
+    {
+        return;
+    }
+
+    MonoClass* klass = mono_object_get_class(instance);
+    if (!klass)
+    {
+        return;
+    }
+
+    MonoBehaviorRecord record{};
+    record.id = component->GetBehaviorHandle();
+    record.instance = instance;
+
+    for (const auto& eventName : *eventsOpt)
+    {
+        auto eventType = ToBehaviorEvent(eventName);
+        if (!eventType)
+        {
+            continue;
+        }
+
+        MonoMethod* method = mono_class_get_method_from_name(klass, eventName.c_str(), ExpectedParameterCount(*eventType));
+        if (!method)
+        {
+            continue;
+        }
+
+        Core::DelegateHandle handle = RegisterEventHandler(scene, record.id, method, *eventType, eventName);
+        if (!handle.IsValid())
+        {
+            continue;
+        }
+
+        record.events.push_back({ method, handle, *eventType });
+    }
+
+    if (record.events.empty())
+    {
+        return;
+    }
+
+    std::scoped_lock lock{ m_behaviorMutex };
+    m_behaviorRecords[component] = std::move(record);
+}
+
+void MonoManager::UnbindScriptEvents(CSharpScriptComponent* component)
+{
+    if (!component)
+    {
+        return;
+    }
+
+    MonoBehaviorRecord record{};
+    {
+        std::scoped_lock lock{ m_behaviorMutex };
+        auto it = m_behaviorRecords.find(component);
+        if (it == m_behaviorRecords.end())
+        {
+            return;
+        }
+
+        record = std::move(it->second);
+        m_behaviorRecords.erase(it);
+    }
+
+    GameObject* owner = component->GetOwner();
+    Scene* scene = owner ? owner->GetScene() : nullptr;
+    if (!scene)
+    {
+        return;
+    }
+
+    for (auto& pair : record.events)
+    {
+        if (!pair.handle.IsValid())
+        {
+            continue;
+        }
+
+        switch (pair.event)
+        {
+        case MonoBehaviorEvent::Awake:
+            scene->AwakeEvent -= pair.handle;
+            break;
+        case MonoBehaviorEvent::OnEnable:
+            scene->OnEnableEvent -= pair.handle;
+            break;
+        case MonoBehaviorEvent::Start:
+            scene->StartEvent -= pair.handle;
+            break;
+        case MonoBehaviorEvent::FixedUpdate:
+            scene->FixedUpdateEvent -= pair.handle;
+            break;
+        case MonoBehaviorEvent::Update:
+            scene->UpdateEvent -= pair.handle;
+            break;
+        case MonoBehaviorEvent::LateUpdate:
+            scene->LateUpdateEvent -= pair.handle;
+            break;
+        case MonoBehaviorEvent::OnDisable:
+            scene->OnDisableEvent -= pair.handle;
+            break;
+        case MonoBehaviorEvent::OnDestroy:
+            scene->OnDestroyEvent -= pair.handle;
+            break;
+        }
+    }
 }
 #endif // UNUSE_MONO_LIB

--- a/ScriptBinder/MonoManager.h
+++ b/ScriptBinder/MonoManager.h
@@ -3,9 +3,12 @@
 #ifndef UNUSE_MONO_LIB
 #include <DLLAcrossSingleton.h>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 #include <optional>
+#include <mutex>
+#include "MonoBehaviorRecord.h"
 
 #include <mono/jit/jit.h>
 #include <mono/metadata/assembly.h>
@@ -13,6 +16,7 @@
 #include <mono/metadata/attrdefs.h>
 #include <mono/metadata/mono-debug.h>
 
+class CSharpScriptComponent;
 class MonoManager : public DLLCore::Singleton<MonoManager>
 {
 public:
@@ -74,6 +78,10 @@ public:
     // 이미지/어셈블리 접근
     MonoImage* GetImage(const std::string& assemblyName) const;
 
+    // C# 스크립트 이벤트 바인딩
+    void BindScriptEvents(CSharpScriptComponent* component);
+    void UnbindScriptEvents(CSharpScriptComponent* component);
+
 private:
     MonoManager() = default;
     ~MonoManager() = default;
@@ -83,11 +91,23 @@ private:
     bool CreateAppDomain(const char* domainName);
     void DestroyAppDomain();
 
+    Core::DelegateHandle RegisterEventHandler(class Scene* scene,
+        MonoBehaviorHandle handle,
+        MonoMethod* method,
+        MonoBehaviorEvent eventType,
+        std::string_view eventName) const;
+    void InvokeMonoBehavior(MonoBehaviorHandle handle, MonoMethod* method, void** args, std::string_view eventName) const;
+    std::optional<std::vector<std::string>> LoadEventList(const CSharpScriptComponent* component) const;
+    static std::optional<MonoBehaviorEvent> ToBehaviorEvent(std::string_view name);
+    static int ExpectedParameterCount(MonoBehaviorEvent eventType);
+
 private:
     MonoDomain* m_rootDomain{ nullptr };
     MonoDomain* m_appDomain{ nullptr };
 
     std::unordered_map<std::string, AssemblyPack> m_assemblies;
+    std::unordered_map<CSharpScriptComponent*, MonoBehaviorRecord> m_behaviorRecords;
+    mutable std::mutex m_behaviorMutex;
 };
 static auto MonoManagers = MonoManager::GetInstance();
 #endif // !UNUSE_MONO_LIB


### PR DESCRIPTION
## Summary
- extend Mono behavior metadata to capture which scene delegates are bound for managed instances
- add MonoManager helpers that read script meta files, bind supported events, and remove them when the instance is released
- hook CSharpScriptComponent lifecycle into MonoManager so C# components register and unregister their events automatically

## Testing
- not run (Mono support remains disabled by build flag)


------
https://chatgpt.com/codex/tasks/task_e_6909507d754c832d962b9854aca21380