### PR TITLE
Replace yaml-cpp reflection backend with rapidyaml

### DIFF
--- a/EngineGUIWindow/InspectorWindow.cpp
+++ b/EngineGUIWindow/InspectorWindow.cpp
@@ -98,10 +98,10 @@ InspectorWindow::InspectorWindow(SceneRenderer* ptr) :
 
 		bool metaNodeJustSelected = (isSelectedNode && !wasMetaSelectedLastFrame);
 
-		// 3. ¿ì¼±¼øÀ§ °áÁ¤
+		// 3. ìš°ì„ ìˆœìœ„ ê²°ì •
 		if (sceneObjectJustSelected)
 		{
-			// °ÔÀÓ ¿ÀºêÁ§Æ® ¼±ÅÃ ½Ã YAML ¼±ÅÃ ÇØÁ¦
+			// ê²Œì„ ì˜¤ë¸Œì íŠ¸ ì„ íƒ ì‹œ YAML ì„ íƒ í•´ì œ
 			selectedNode = std::nullopt;
 			isSelectedNode = false;
 			wasMetaSelectedLastFrame = false;
@@ -109,7 +109,7 @@ InspectorWindow::InspectorWindow(SceneRenderer* ptr) :
 
 		if (metaNodeJustSelected)
 		{
-			// ¸ŞÅ¸ ÆÄÀÏ ¼±ÅÃ ½Ã °ÔÀÓ ¿ÀºêÁ§Æ® ÇØÁ¦
+			// ë©”íƒ€ íŒŒì¼ ì„ íƒ ì‹œ ê²Œì„ ì˜¤ë¸Œì íŠ¸ í•´ì œ
 			selectedSceneObject = nullptr;
 			prevSelectedSceneObject = nullptr;
 			wasMetaSelectedLastFrame = true;
@@ -253,7 +253,7 @@ InspectorWindow::InspectorWindow(SceneRenderer* ptr) :
 						SpriteRenderer* sprite = dynamic_cast<SpriteRenderer*>(component.get());
 						if (nullptr != sprite)
 						{
-							//ÀÌ°Ç ¹º ¹ö±×ÁÒ?
+							//ì´ê±´ ë­” ë²„ê·¸ì£ ?
 							ImGuiDrawHelperSpriteRenderer(sprite);
 						}
 					}
@@ -268,7 +268,7 @@ InspectorWindow::InspectorWindow(SceneRenderer* ptr) :
 					else if (componentTypeID == type_guid(SoundComponent))
 					{
 						SoundComponent* snd = dynamic_cast<SoundComponent*>(component.get());
-						if (snd) ImGuiDrawHelperSoundComponent(snd);   // Ä¿½ºÅÒ ÀÎ½ºÆåÅÍ È£Ãâ
+						if (snd) ImGuiDrawHelperSoundComponent(snd);   // ì»¤ìŠ¤í…€ ì¸ìŠ¤í™í„° í˜¸ì¶œ
 					}
 					else if (type)
 					{
@@ -286,23 +286,23 @@ InspectorWindow::InspectorWindow(SceneRenderer* ptr) :
 			}
 			
 			ImGui::Separator();
-			ImVec2 windowSize = ImGui::GetWindowSize();      // ÇöÀç À©µµ¿ìÀÇ ÀüÃ¼ Å©±â
-			ImVec2 buttonSize = ImVec2(180, 0);              // ¹öÆ° °¡·Î Å©±â (¼¼·Î´Â ÀÚµ¿ °è»êµÊ)
+			ImVec2 windowSize = ImGui::GetWindowSize();      // í˜„ì¬ ìœˆë„ìš°ì˜ ì „ì²´ í¬ê¸°
+			ImVec2 buttonSize = ImVec2(180, 0);              // ë²„íŠ¼ ê°€ë¡œ í¬ê¸° (ì„¸ë¡œëŠ” ìë™ ê³„ì‚°ë¨)
 
 			static ImGuiTextFilter searchFilter;
 
-			ImGui::SetCursorPosX((windowSize.x - buttonSize.x) * 0.5f);  // ¼öÆò Áß¾Ó Á¤·Ä
+			ImGui::SetCursorPosX((windowSize.x - buttonSize.x) * 0.5f);  // ìˆ˜í‰ ì¤‘ì•™ ì •ë ¬
 
 			if (ImGui::Button("Add Component", buttonSize))
 			{
 				ImGui::OpenPopup("AddComponent");
 			}
 
-			ImGui::SetNextWindowSize(ImVec2(windowSize.x, 0)); // ¿øÇÏ´Â »çÀÌÁî ÁöÁ¤
+			ImGui::SetNextWindowSize(ImVec2(windowSize.x, 0)); // ì›í•˜ëŠ” ì‚¬ì´ì¦ˆ ì§€ì •
 			if (ImGui::BeginPopup("AddComponent"))
 			{
-				ImGui::TextColored(ImVec4(1, 1, 1, 1), "Add Component"); // ³ë¶õ»ö ÅØ½ºÆ®
-				ImGui::Separator(); // ±¸ºĞ¼±
+				ImGui::TextColored(ImVec4(1, 1, 1, 1), "Add Component"); // ë…¸ë€ìƒ‰ í…ìŠ¤íŠ¸
+				ImGui::Separator(); // êµ¬ë¶„ì„ 
 
 				float availableWidth = ImGui::GetContentRegionAvail().x;
 				searchFilter.Draw(ICON_FA_MARKER "Search", availableWidth);
@@ -340,18 +340,18 @@ InspectorWindow::InspectorWindow(SceneRenderer* ptr) :
 				ImGui::EndPopup();
 			}
 
-			// ´ÙÀ½ ÇÁ·¹ÀÓ¿¡¼­ ¿­±â
+			// ë‹¤ìŒ í”„ë ˆì„ì—ì„œ ì—´ê¸°
 			if (m_openScriptPopup)
 			{
 				ImGui::OpenPopup("Scripts");
 				m_openScriptPopup = false;
 			}
 
-			ImGui::SetNextWindowSize(ImVec2(windowSize.x, 0)); // ¿øÇÏ´Â »çÀÌÁî ÁöÁ¤
+			ImGui::SetNextWindowSize(ImVec2(windowSize.x, 0)); // ì›í•˜ëŠ” ì‚¬ì´ì¦ˆ ì§€ì •
 			if (ImGui::BeginPopup("Scripts"))
 			{
-				ImGui::TextColored(ImVec4(1, 1, 1, 1), "ScriptComponent"); // ³ë¶õ»ö ÅØ½ºÆ®
-				ImGui::Separator(); // ±¸ºĞ¼±
+				ImGui::TextColored(ImVec4(1, 1, 1, 1), "ScriptComponent"); // ë…¸ë€ìƒ‰ í…ìŠ¤íŠ¸
+				ImGui::Separator(); // êµ¬ë¶„ì„ 
 
 				float availableWidth = ImGui::GetContentRegionAvail().x;
 				searchFilter.Draw(ICON_FA_MARKER "Search", availableWidth);
@@ -372,7 +372,7 @@ InspectorWindow::InspectorWindow(SceneRenderer* ptr) :
 				ImGui::EndPopup();
 			}
 
-			// ´ÙÀ½ ÇÁ·¹ÀÓ¿¡¼­ ¿­±â
+			// ë‹¤ìŒ í”„ë ˆì„ì—ì„œ ì—´ê¸°
 			if (m_openNewScriptPopup)
 			{
 				ImGui::OpenPopup("NewScript");
@@ -390,11 +390,11 @@ InspectorWindow::InspectorWindow(SceneRenderer* ptr) :
 				isOpen = false;
 			}
 
-			ImGui::SetNextWindowSize(ImVec2(windowSize.x, 0)); // ¿øÇÏ´Â »çÀÌÁî ÁöÁ¤
+			ImGui::SetNextWindowSize(ImVec2(windowSize.x, 0)); // ì›í•˜ëŠ” ì‚¬ì´ì¦ˆ ì§€ì •
 			if (ImGui::BeginPopup("NewScript"))
 			{
-				ImGui::TextColored(ImVec4(1, 1, 1, 1), "New ScriptComponent"); // ³ë¶õ»ö ÅØ½ºÆ®
-				ImGui::Separator(); // ±¸ºĞ¼±
+				ImGui::TextColored(ImVec4(1, 1, 1, 1), "New ScriptComponent"); // ë…¸ë€ìƒ‰ í…ìŠ¤íŠ¸
+				ImGui::Separator(); // êµ¬ë¶„ì„ 
 
 				float availableWidth = ImGui::GetContentRegionAvail().x;
 				searchFilter.Draw(ICON_FA_MARKER "Search", availableWidth);
@@ -482,13 +482,11 @@ InspectorWindow::InspectorWindow(SceneRenderer* ptr) :
 				{
 					try
 					{
-						YAML::Emitter emitter;
-						emitter << *selectedNode;
-
 						std::ofstream fout(selectedMetaFilePath);
 						if (fout.is_open())
 						{
-							fout << emitter.c_str();
+							const std::string serialized = YAML::Dump(*selectedNode);
+							fout << serialized;
 							fout.close();
 						}
 						else
@@ -567,22 +565,22 @@ void InspectorWindow::ImGuiDrawHelperGameObjectBaseInfo(GameObject* gameObject)
 	selectedLayerIndex = TagManagers->GetLayerIndex(selectedLayer.ToString());
 	if (selectedTagIndex < 0 || selectedTagIndex >= tagCount)
 	{
-		selectedTagIndex = 0; // ±âº»°ªÀ¸·Î Ã¹ ¹øÂ° ÅÂ±× ¼±ÅÃ
+		selectedTagIndex = 0; // ê¸°ë³¸ê°’ìœ¼ë¡œ ì²« ë²ˆì§¸ íƒœê·¸ ì„ íƒ
 	}
-	// Tag ÄŞº¸¹Ú½º
+	// Tag ì½¤ë³´ë°•ìŠ¤
 	ImGui::Text("Tag");
 	ImGui::SameLine();
-	ImGui::SetNextItemWidth(90.0f); // ÇÈ¼¿ ´ÜÀ§·Î ³Êºñ ¼³Á¤
+	ImGui::SetNextItemWidth(90.0f); // í”½ì…€ ë‹¨ìœ„ë¡œ ë„ˆë¹„ ì„¤ì •
 	if (ImGui::BeginCombo("##TagCombo", tagNames[selectedTagIndex]))
 	{
 		for (int i = 0; i <= tagCount; ++i)
 		{
 			bool isSelected = false;
-			if (i == tagCount) // "Add Tag" Ç×¸ñ
+			if (i == tagCount) // "Add Tag" í•­ëª©
 			{
 				if (ImGui::Selectable("Add Tag"))
 				{
-					m_openNewTagPopup = true; // ÆË¾÷ ¿­±â ÇÃ·¡±× ¼³Á¤
+					m_openNewTagPopup = true; // íŒì—… ì—´ê¸° í”Œë˜ê·¸ ì„¤ì •
 				}
 			}
 			else
@@ -593,7 +591,7 @@ void InspectorWindow::ImGuiDrawHelperGameObjectBaseInfo(GameObject* gameObject)
 					TagManagers->RemoveTagFromObject(selectedTag.ToString(), gameObject);
 					selectedTag = tagNames[i];
 					TagManagers->AddTagToObject(selectedTag.ToString(), gameObject);
-					selectedTagIndex = i; // ¼±ÅÃµÈ ÀÎµ¦½º ¾÷µ¥ÀÌÆ®
+					selectedTagIndex = i; // ì„ íƒëœ ì¸ë±ìŠ¤ ì—…ë°ì´íŠ¸
 				}
 			}
 
@@ -605,17 +603,17 @@ void InspectorWindow::ImGuiDrawHelperGameObjectBaseInfo(GameObject* gameObject)
 	ImGui::SameLine();
 	ImGui::Text("Layer");
 	ImGui::SameLine();
-	ImGui::SetNextItemWidth(90.0f); // ÇÈ¼¿ ´ÜÀ§·Î ³Êºñ ¼³Á¤
+	ImGui::SetNextItemWidth(90.0f); // í”½ì…€ ë‹¨ìœ„ë¡œ ë„ˆë¹„ ì„¤ì •
 	if (ImGui::BeginCombo("##LayerCombo", layerNames[selectedLayerIndex]))
 	{
 		for (int i = 0; i <= layerCount; ++i)
 		{
 			bool isSelected = false;
-			if (i == layerCount) // "Add Layer" Ç×¸ñ
+			if (i == layerCount) // "Add Layer" í•­ëª©
 			{
 				if (ImGui::Selectable("Add Layer"))
 				{
-					m_openNewLayerPopup = true; // ÆË¾÷ ¿­±â ÇÃ·¡±× ¼³Á¤
+					m_openNewLayerPopup = true; // íŒì—… ì—´ê¸° í”Œë˜ê·¸ ì„¤ì •
 				}
 			}
 			else
@@ -625,9 +623,9 @@ void InspectorWindow::ImGuiDrawHelperGameObjectBaseInfo(GameObject* gameObject)
 				{
 					TagManagers->RemoveObjectFromLayer(selectedLayer.ToString(), gameObject);
 					selectedLayer = layerNames[i];
-					gameObject->SetCollisionType(); // Ãæµ¹ Å¸ÀÔ ¾÷µ¥ÀÌÆ®
+					gameObject->SetCollisionType(); // ì¶©ëŒ íƒ€ì… ì—…ë°ì´íŠ¸
 					TagManagers->AddObjectToLayer(selectedLayer.ToString(), gameObject);
-					selectedLayerIndex = i; // ¼±ÅÃµÈ ÀÎµ¦½º ¾÷µ¥ÀÌÆ®
+					selectedLayerIndex = i; // ì„ íƒëœ ì¸ë±ìŠ¤ ì—…ë°ì´íŠ¸
 				}
 			}
 
@@ -643,16 +641,16 @@ void InspectorWindow::ImGuiDrawHelperGameObjectBaseInfo(GameObject* gameObject)
 	if (m_openNewTagPopup)
 	{
 		ImGui::OpenPopup("New Tag");
-		m_openNewTagPopup = false; // ÆË¾÷ ¿­±â ÇÃ·¡±× ÃÊ±âÈ­
+		m_openNewTagPopup = false; // íŒì—… ì—´ê¸° í”Œë˜ê·¸ ì´ˆê¸°í™”
 	}
 
 	if (m_openNewLayerPopup)
 	{
 		ImGui::OpenPopup("New Layer");
-		m_openNewLayerPopup = false; // ÆË¾÷ ¿­±â ÇÃ·¡±× ÃÊ±âÈ­
+		m_openNewLayerPopup = false; // íŒì—… ì—´ê¸° í”Œë˜ê·¸ ì´ˆê¸°í™”
 	}
 
-	// New Tag ÆË¾÷
+	// New Tag íŒì—…
 	if (ImGui::BeginPopup("New Tag"))
 	{
 		static char newTagName[64] = "";
@@ -663,8 +661,8 @@ void InspectorWindow::ImGuiDrawHelperGameObjectBaseInfo(GameObject* gameObject)
 			{
 				TagManagers->AddTag(newTagName);
 				selectedTag = newTagName;
-				selectedTagIndex = tagCount; // »õ·Î Ãß°¡µÈ ÅÂ±× ÀÎµ¦½º
-				tagCount = TagManagers->GetTags().size(); // ÅÂ±× °³¼ö ¾÷µ¥ÀÌÆ®
+				selectedTagIndex = tagCount; // ìƒˆë¡œ ì¶”ê°€ëœ íƒœê·¸ ì¸ë±ìŠ¤
+				tagCount = TagManagers->GetTags().size(); // íƒœê·¸ ê°œìˆ˜ ì—…ë°ì´íŠ¸
 			}
 			ImGui::CloseCurrentPopup();
 		}
@@ -676,7 +674,7 @@ void InspectorWindow::ImGuiDrawHelperGameObjectBaseInfo(GameObject* gameObject)
 		ImGui::EndPopup();
 	}
 
-	// New Layer ÆË¾÷
+	// New Layer íŒì—…
 	if (ImGui::BeginPopup("New Layer"))
 	{
 		static char newLayerName[64] = "";
@@ -687,8 +685,8 @@ void InspectorWindow::ImGuiDrawHelperGameObjectBaseInfo(GameObject* gameObject)
 			{
 				TagManagers->AddLayer(newLayerName);
 				selectedLayer = newLayerName;
-				selectedLayerIndex = layerCount; // »õ·Î Ãß°¡µÈ ·¹ÀÌ¾î ÀÎµ¦½º
-				layerCount = TagManagers->GetLayers().size(); // ·¹ÀÌ¾î °³¼ö ¾÷µ¥ÀÌÆ®
+				selectedLayerIndex = layerCount; // ìƒˆë¡œ ì¶”ê°€ëœ ë ˆì´ì–´ ì¸ë±ìŠ¤
+				layerCount = TagManagers->GetLayers().size(); // ë ˆì´ì–´ ê°œìˆ˜ ì—…ë°ì´íŠ¸
 			}
 			ImGui::CloseCurrentPopup();
 		}
@@ -703,7 +701,7 @@ void InspectorWindow::ImGuiDrawHelperGameObjectBaseInfo(GameObject* gameObject)
 
 void InspectorWindow::ImGuiDrawHelperTransformComponent(GameObject* gameObject)
 {
-	// ÇöÀç Æ®·£½ºÆû °ª
+	// í˜„ì¬ íŠ¸ëœìŠ¤í¼ ê°’
 	Mathf::Vector4& position = gameObject->m_transform.position;
 	Mathf::Vector4& rotation = gameObject->m_transform.rotation;
 	Mathf::Vector4& scale = gameObject->m_transform.scale;
@@ -942,13 +940,13 @@ void InspectorWindow::ImGuiDrawHelperBT(BehaviorTreeComponent* BTComponent)
 		}
 	}
 
-	// Behavior Tree ÀÌ¸§ Ç¥½Ã
+	// Behavior Tree ì´ë¦„ í‘œì‹œ
 	if (!BTComponent->name.empty())
 	{
 		ImGui::Text("Behavior Tree: %s", BTComponent->name.c_str());
 	}
 
-	//BlackBoard ÀÌ¸§ Ç¥½Ã
+	//BlackBoard ì´ë¦„ í‘œì‹œ
 	if (!BTComponent->blackBoardName.empty())
 	{
 		ImGui::Text("BlackBoard: %s", BTComponent->blackBoardName.c_str());
@@ -972,7 +970,7 @@ void InspectorWindow::ImGuiDrawHelperVolume(VolumeComponent* volumeComponent)
 			FileGuid guid = DataSystems->GetFileGuid(filepath);
 			if (guid != nullFileGuid)
 			{
-				// ÀÌ¹Ì ÇÁ·ÎÆÄÀÏÀÌ Á¸ÀçÇÏ´Â °æ¿ì
+				// ì´ë¯¸ í”„ë¡œíŒŒì¼ì´ ì¡´ì¬í•˜ëŠ” ê²½ìš°
 				if (volumeComponent->m_volumeProfileGuid != nullFileGuid)
 				{
 					Debug->LogWarning("Volume profile already exists. Replacing with new profile.");
@@ -1256,7 +1254,7 @@ void InspectorWindow::ImGuiDrawHelperImageComponent(ImageComponent* imageCompone
 		}
 		ImGui::Text("Image");
 		ImGui::SameLine();
-		ImGui::SetNextItemWidth(150.0f); // ÇÈ¼¿ ´ÜÀ§·Î ³Êºñ ¼³Á¤
+		ImGui::SetNextItemWidth(150.0f); // í”½ì…€ ë‹¨ìœ„ë¡œ ë„ˆë¹„ ì„¤ì •
 		if (ImGui::BeginCombo("##TextureCombo", items[currentTextureIndex]))
 		{
 			for (int i = 0; i < count; ++i)
@@ -1342,7 +1340,7 @@ void InspectorWindow::ImGuiDrawHelperImageComponent(ImageComponent* imageCompone
 
 	ImGui::Text("Navigation");
 	auto originNaviContainer = imageComponent->GetNavigations();
-	std::array<Navigation, 4> naviContainer{}; // º¹»çº» »ı¼º
+	std::array<Navigation, 4> naviContainer{}; // ë³µì‚¬ë³¸ ìƒì„±
 
 	for (auto navi : originNaviContainer)
 	{
@@ -1522,9 +1520,9 @@ void InspectorWindow::ImGuiDrawHelperSoundComponent(SoundComponent* sc)
 {
 	using namespace ImGui;
 
-	// ¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡
+	// â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 	//  Clip / Picker
-	// ¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡
+	// â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 	TextUnformatted("Clip");
 	ImGui::SameLine();
 	SetNextItemWidth(240);
@@ -1538,9 +1536,9 @@ void InspectorWindow::ImGuiDrawHelperSoundComponent(SoundComponent* sc)
 		m_openClipPicker = true;
 	}
 
-	// ¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡
+	// â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 	//  Bus / Basic Params
-	// ¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡
+	// â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 	SeparatorText("Bus / Params");
 
 	const char* busNames[] = { "BGM","SFX","PLAYER","MONSTER","UI" };
@@ -1561,7 +1559,7 @@ void InspectorWindow::ImGuiDrawHelperSoundComponent(SoundComponent* sc)
 	Checkbox("Loop", &sc->loop); ImGui::SameLine();
 	Checkbox("Play On Start", &sc->playOnStart);
 
-	// ·çÇÁ »óÅÂ º¯°æ Áï½Ã Ã¤³Î¿¡ ¹İ¿µ
+	// ë£¨í”„ ìƒíƒœ ë³€ê²½ ì¦‰ì‹œ ì±„ë„ì— ë°˜ì˜
 	if (loopBefore != sc->loop) {
 		auto applyLoop = [&](FMOD::Channel* ch) {
 			if (!ch) return;
@@ -1575,9 +1573,9 @@ void InspectorWindow::ImGuiDrawHelperSoundComponent(SoundComponent* sc)
 		applyLoop(sc->Get3DChannel());
 	}
 
-	// ¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡
+	// â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 	//  Spatial
-	// ¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡
+	// â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 	SeparatorText("Spatial");
 	Checkbox("Spatial (Blend 2D+3D)", &sc->spatial);
 
@@ -1599,12 +1597,12 @@ void InspectorWindow::ImGuiDrawHelperSoundComponent(SoundComponent* sc)
 		bool rollChanged = ImGui::Combo("Rolloff", &roll, rolloffNames, IM_ARRAYSIZE(rolloffNames));
 		sc->rolloff = (Rolloff)roll;
 
-		// ±×·¡ÇÁ: spatialÀÌ¸é Ç×»ó Ç¥½Ã
+		// ê·¸ë˜í”„: spatialì´ë©´ í•­ìƒ í‘œì‹œ
 		ImGui::SeparatorText("Distance Rolloff Curve");
 
 		const bool isCustom = (sc->rolloff == Rolloff::Custom);
 
-		// Linear /Inverse ¼±ÅÃ ½Ã: ÀÚµ¿ °î¼±À¸·Î µ¿±âÈ­(ÀĞ±âÀü¿ë)
+		// Linear /Inverse ì„ íƒ ì‹œ: ìë™ ê³¡ì„ ìœ¼ë¡œ ë™ê¸°í™”(ì½ê¸°ì „ìš©)
 		if (!isCustom) {
 			if (rollChanged || minBefore != sc->minDistance || maxBefore != sc->maxDistance || sc->localRolloffCurve.size() < 2) {
 				if (sc->rolloff == Rolloff::Linear)  BuildLinearCurve(sc->localRolloffCurve, sc->minDistance, sc->maxDistance);
@@ -1614,11 +1612,11 @@ void InspectorWindow::ImGuiDrawHelperSoundComponent(SoundComponent* sc)
 			ImGui::TextDisabled("Rolloff is %s - curve preview (read-only).", sc->rolloff == Rolloff::Linear ? "Linear" : "Inverse");
 		}
 		else {
-			// Custom: ¿¡µğÆ® °¡´É
+			// Custom: ì—ë””íŠ¸ ê°€ëŠ¥
 			if (sc->localRolloffCurve.size() < 2) {
 				sc->localRolloffCurve = { {0.f,1.f}, { std::max(0.1f, sc->maxDistance), 0.f } };
 			}
-			// maxDistance º¯°æ ½Ã ¸¶Áö¸· Á¡ X¸¦ ¹üÀ§ ³»·Î º¸Á¤(ÆíÁı ³»¿ëÀº À¯Áö)
+			// maxDistance ë³€ê²½ ì‹œ ë§ˆì§€ë§‰ ì  Xë¥¼ ë²”ìœ„ ë‚´ë¡œ ë³´ì •(í¸ì§‘ ë‚´ìš©ì€ ìœ ì§€)
 			sc->localRolloffCurve.back().distance = std::clamp(sc->localRolloffCurve.back().distance, 0.1f, std::max(0.1f, sc->maxDistance));
 
 			if (ImGui::SmallButton("Reset to Default")) {
@@ -1628,7 +1626,7 @@ void InspectorWindow::ImGuiDrawHelperSoundComponent(SoundComponent* sc)
 			ImGui::TextDisabled("Custom mode - drag points, double-click to add, right-click/Delete to remove.");
 		}
 
-		// ½Ç½Ã°£ 3D Ã¤³Î ¹İ¿µ(À§Ä¡/°Å¸®/·Ñ¿ÀÇÁ ¸ğµå µî)
+		// ì‹¤ì‹œê°„ 3D ì±„ë„ ë°˜ì˜(ìœ„ì¹˜/ê±°ë¦¬/ë¡¤ì˜¤í”„ ëª¨ë“œ ë“±)
 		if (auto* ch3 = sc->Get3DChannel()) {
 			FMOD_VECTOR p{ sc->position.x, sc->position.y, sc->position.z };
 			FMOD_VECTOR v{ sc->velocity.x, sc->velocity.y, sc->velocity.z };
@@ -1651,14 +1649,14 @@ void InspectorWindow::ImGuiDrawHelperSoundComponent(SoundComponent* sc)
 		}
 	}
 
-	// ¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡
+	// â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 	//  Reverb Send
-	// ¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡
+	// â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 	SeparatorText("Reverb Send");
 	bool useRevBefore = sc->useReverbSend;
 	Checkbox("Enable Reverb Send", &sc->useReverbSend);
 
-	// dB ½½¶óÀÌ´õ(-80~+10), ³»ºÎ´Â ¼±Çü(0~1)·Î º¯È¯ÇØ¼­ FMOD¿¡ Àû¿ë
+	// dB ìŠ¬ë¼ì´ë”(-80~+10), ë‚´ë¶€ëŠ” ì„ í˜•(0~1)ë¡œ ë³€í™˜í•´ì„œ FMODì— ì ìš©
 	SetNextItemWidth(260);
 	DragFloat("Reverb Level (dB)", &sc->reverbLevel, 0.1f, -80.0f, 10.0f, "%.1f dB");
 	SetNextItemWidth(200);
@@ -1678,21 +1676,21 @@ void InspectorWindow::ImGuiDrawHelperSoundComponent(SoundComponent* sc)
 		applyReverb(sc->Get2DChannel());
 		applyReverb(sc->Get3DChannel());
 	}
-	// °ªÀÌ ¹Ù²î¸é Ç×»ó Àû¿ë
+	// ê°’ì´ ë°”ë€Œë©´ í•­ìƒ ì ìš©
 	if (IsItemEdited() || IsItemDeactivatedAfterEdit()) {
 		applyReverb(sc->Get2DChannel());
 		applyReverb(sc->Get3DChannel());
 	}
 
-	// ¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡
+	// â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 	//  Preview Controls
-	// ¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡¦¡
+	// â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 	Separator();
 	if (Button("Play")) { sc->Play(); } ImGui::SameLine();
 	if (Button("Stop")) { sc->Stop(); } ImGui::SameLine();
 	if (Button("OneShot")) { sc->PlayOneShot(); }
 
-	// º¼·ı/ÇÇÄ¡/ÇÁ¶óÀÌ¾î¸®Æ¼ º¯°æ ½Ç½Ã°£ ¹İ¿µ(Ã¤³Î »ì¾ÆÀÖÀ» ¶§)
+	// ë³¼ë¥¨/í”¼ì¹˜/í”„ë¼ì´ì–´ë¦¬í‹° ë³€ê²½ ì‹¤ì‹œê°„ ë°˜ì˜(ì±„ë„ ì‚´ì•„ìˆì„ ë•Œ)
 	auto applyBasic = [&](FMOD::Channel* ch) {
 		if (!ch) return;
 		ch->setVolume(sc->volume);
@@ -1823,7 +1821,7 @@ bool InspectorWindow::DrawRolloffCurveEditor(std::vector<CurvePoint>& curve, flo
 		return changed;
 	}
 	else {
-		// readOnly ¸ğµå: »óÈ£ÀÛ¿ë ¾øÀ½, ¾È³»¸¸
+		// readOnly ëª¨ë“œ: ìƒí˜¸ì‘ìš© ì—†ìŒ, ì•ˆë‚´ë§Œ
 		if (hovered) SetTooltip("Graph is read-only (driven by Rolloff mode).");
 		Dummy(size);
 		if (outSelected) *outSelected = -1;
@@ -1836,14 +1834,14 @@ void InspectorWindow::DrawSoundClipPicker()
 	using namespace ImGui;
 	if (!m_openClipPicker) return;
 
-	// µ¶¸³ À©µµ¿ì(¸ğ´Ş ´À³¦)
+	// ë…ë¦½ ìœˆë„ìš°(ëª¨ë‹¬ ëŠë‚Œ)
 	SetNextWindowSize(ImVec2(520, 480), ImGuiCond_Appearing);
 	if (Begin("Select Audio Clip", &m_openClipPicker,
 		ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoDocking))
 	{
-		// »ó´Ü: °Ë»ö/¸®ÇÁ·¹½Ã
+		// ìƒë‹¨: ê²€ìƒ‰/ë¦¬í”„ë ˆì‹œ
 		if (InputTextWithHint("##search", "Search clip key...", &m_clipSearch)) {
-			// ÀÔ·Â ½Ã Áï½Ã ÇÊÅÍ ¹İ¿µ
+			// ì…ë ¥ ì‹œ ì¦‰ì‹œ í•„í„° ë°˜ì˜
 		}
 		SameLine();
 		if (Button("Refresh")) {
@@ -1851,11 +1849,11 @@ void InspectorWindow::DrawSoundClipPicker()
 		}
 		Separator();
 
-		// ÇÊÅÍ¸µ
+		// í•„í„°ë§
 		auto toLower = [](std::string s) { std::transform(s.begin(), s.end(), s.begin(), ::tolower); return s; };
 		std::string q = toLower(m_clipSearch);
 
-		// ¸®½ºÆ® ¿µ¿ª
+		// ë¦¬ìŠ¤íŠ¸ ì˜ì—­
 		BeginChild("##cliplist", ImVec2(0, -48), true);
 		static int selectedIndex = -1;
 		const int N = (int)m_clipKeyCache.size();
@@ -1868,10 +1866,10 @@ void InspectorWindow::DrawSoundClipPicker()
 				selectedIndex = i;
 			}
 
-			// ¿ìÃø ÇÁ¸®ºä ¹öÆ°
+			// ìš°ì¸¡ í”„ë¦¬ë·° ë²„íŠ¼
 			if (IsItemHovered() && IsMouseDoubleClicked(0)) 
 			{
-				// ´õºíÅ¬¸¯ = ¼±ÅÃ È®Á¤
+				// ë”ë¸”í´ë¦­ = ì„ íƒ í™•ì •
 				if (m_clipPickerTarget && i >= 0) m_clipPickerTarget->clipKey = key;
 				m_openClipPicker = false;
 				selectedIndex = -1;
@@ -1882,7 +1880,7 @@ void InspectorWindow::DrawSoundClipPicker()
 			{
 				if (m_clipPickerTarget) 
 				{
-					// ¹Ì¸®µè±â: ÇöÀç Å¸°Ù ¹ö½º/º¼·ı/ÇÇÄ¡ »ç¿ë
+					// ë¯¸ë¦¬ë“£ê¸°: í˜„ì¬ íƒ€ê²Ÿ ë²„ìŠ¤/ë³¼ë¥¨/í”¼ì¹˜ ì‚¬ìš©
 					FMOD_VECTOR pos{ m_clipPickerTarget->position.x,
 									 m_clipPickerTarget->position.y,
 									 m_clipPickerTarget->position.z };
@@ -1907,7 +1905,7 @@ void InspectorWindow::DrawSoundClipPicker()
 		}
 		EndChild();
 
-		// ÇÏ´Ü ¹öÆ°
+		// í•˜ë‹¨ ë²„íŠ¼
 		BeginDisabled(selectedIndex < 0);
 		if (Button("Use")) 
 		{

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 개발 언어 : C++ 20
 
-외부 종속 라이브러리 : DX11, Imgui, Assimp, DirextXTK, nlohmann-json, PhysX, imguizmo, spdlog, pugixml, magic-enum, yaml-cpp, efsw, meshoptimizer, boost-uuid, mimalloc, LZ4
+외부 종속 라이브러리 : DX11, Imgui, Assimp, DirextXTK, nlohmann-json, PhysX, imguizmo, spdlog, pugixml, magic-enum, rapidyaml, efsw, meshoptimizer, boost-uuid, mimalloc, LZ4
 
 ## CreatorEngine 기술 스택 및 라이브러리 개요
 
@@ -53,7 +53,7 @@ CreatorEngine은 Windows 기반 DX11 렌더링 파이프라인과 C++20 모듈�
 
 ### 데이터, 메타 & 직렬화
 - **JSON 직렬화**: nlohmann::json을 사용해 파티클 이펙트, 렌더 모듈, 벡터 타입 등을 직렬화/역직렬화합니다.
-- **YAML 설정**: 엔진 환경설정과 프로젝트 메타데이터는 yaml-cpp 기반 싱글턴에서 관리하며, MSBuild 경로 등 개발자 옵션을 노출합니다.
+- **YAML 설정**: 엔진 환경설정과 프로젝트 메타데이터는 rapidyaml 기반 싱글턴에서 관리하며, MSBuild 경로 등 개발자 옵션을 노출합니다.
 - **XML 처리**: 스크립트 핫로드 시스템은 pugixml을 포함해 외부 메타 데이터를 파싱하고 빌드 파이프라인과 연계합니다.
 - **자산 메타 감시**: efsw 파일 감시기를 통해 메타 파일 생성/삭제를 감지하고, 누락된 `.meta` 파일을 자동 생성합니다.
 - **자산 GUID**: boost::uuids 기반 `FileGuid` 타입이 자산 경로에 대한 안정적인 식별자를 생성·역직렬화합니다.

--- a/yaml-cpp/yaml.h
+++ b/yaml-cpp/yaml.h
@@ -1,0 +1,655 @@
+#pragma once
+
+#ifndef YAML_CPP_API
+#define YAML_CPP_API
+#endif
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <ryml.hpp>
+#include <ryml_std.hpp>
+
+namespace YAML
+{
+
+namespace detail
+{
+
+template<typename T>
+struct is_vector : std::false_type {};
+
+template<typename T, typename Alloc>
+struct is_vector<std::vector<T, Alloc>> : std::true_type {};
+
+template<typename T>
+inline constexpr bool is_vector_v = is_vector<T>::value;
+
+template<typename T>
+inline constexpr bool always_false_v = false;
+
+} // namespace detail
+
+enum class EmitterStyle
+{
+        Flow,
+        Block,
+};
+
+class Node
+{
+public:
+        enum class Type
+        {
+                Null,
+                Scalar,
+                Map,
+                Sequence,
+        };
+
+        Node();
+        Node(const Node&) = default;
+        Node(Node&&) noexcept = default;
+        Node& operator=(const Node&) = default;
+        Node& operator=(Node&&) noexcept = default;
+        ~Node() = default;
+
+        bool IsNull() const { return m_data->type == Type::Null; }
+        bool IsScalar() const { return m_data->type == Type::Scalar; }
+        bool IsMap() const { return m_data->type == Type::Map; }
+        bool IsSequence() const { return m_data->type == Type::Sequence; }
+        bool IsDefined() const { return !IsNull(); }
+
+        explicit operator bool() const { return !IsNull(); }
+
+        void SetStyle(EmitterStyle style) { m_data->style = style; }
+        EmitterStyle GetStyle() const { return m_data->style; }
+
+        std::size_t size() const;
+
+        Node& operator[](std::string_view key);
+        Node operator[](std::string_view key) const;
+
+        Node& operator[](std::size_t index);
+        Node operator[](std::size_t index) const;
+
+        Node& operator=(const char* value);
+        Node& operator=(const std::string& value);
+        Node& operator=(std::string_view value);
+
+        template<typename T, typename std::enable_if_t<std::is_arithmetic_v<T>, int> = 0>
+        Node& operator=(T value)
+        {
+                set_scalar(to_string(value));
+                return *this;
+        }
+
+        void push_back(const Node& node);
+
+        template<typename T, typename std::enable_if_t<std::is_arithmetic_v<T>, int> = 0>
+        void push_back(T value)
+        {
+                Node temp;
+                temp = value;
+                push_back(temp);
+        }
+
+        void push_back(const std::string& value)
+        {
+                Node temp;
+                temp = value;
+                push_back(temp);
+        }
+
+        void push_back(std::string_view value)
+        {
+                Node temp;
+                temp = value;
+                push_back(temp);
+        }
+
+        template<typename T>
+        T as() const
+        {
+                if constexpr (std::is_same_v<T, std::string>)
+                {
+                        if (!IsScalar())
+                                return std::string{};
+                        return m_data->scalar;
+                }
+                else if constexpr (std::is_same_v<T, bool>)
+                {
+                        if (!IsScalar())
+                                return false;
+
+                        if (m_data->scalar == "true" || m_data->scalar == "True" || m_data->scalar == "TRUE")
+                                return true;
+                        if (m_data->scalar == "false" || m_data->scalar == "False" || m_data->scalar == "FALSE")
+                                return false;
+
+                        auto trimmed = trim(m_data->scalar);
+                        if (trimmed.empty())
+                                return false;
+
+                        return trimmed != "0";
+                }
+                else if constexpr (std::is_integral_v<T> && std::is_signed_v<T>)
+                {
+                        if (!IsScalar())
+                                return T{};
+                        long long value = 0;
+                        parse_integer(m_data->scalar, value);
+                        return static_cast<T>(value);
+                }
+                else if constexpr (std::is_integral_v<T> && std::is_unsigned_v<T>)
+                {
+                        if (!IsScalar())
+                                return T{};
+                        unsigned long long value = 0;
+                        parse_unsigned(m_data->scalar, value);
+                        return static_cast<T>(value);
+                }
+                else if constexpr (std::is_floating_point_v<T>)
+                {
+                        if (!IsScalar())
+                                return T{};
+                        long double value = 0.0;
+                        parse_floating(m_data->scalar, value);
+                        return static_cast<T>(value);
+                }
+                else if constexpr (detail::is_vector_v<T>)
+                {
+                        using Elem = typename T::value_type;
+                        T result;
+                        if (!IsSequence())
+                                return result;
+                        result.reserve(m_data->sequence.size());
+                        for (const auto& child : m_data->sequence)
+                        {
+                                result.push_back(child.template as<Elem>());
+                        }
+                        return result;
+                }
+                else
+                {
+                        static_assert(detail::always_false_v<T>, "Unsupported YAML::Node conversion");
+                }
+        }
+
+        std::string Scalar() const { return m_data->scalar; }
+
+        class const_iterator
+        {
+        public:
+                struct Key
+                {
+                        std::string value;
+                        std::string Scalar() const { return value; }
+                };
+
+                struct value_type
+                {
+                        Key first;
+                        Node second;
+
+                        bool IsNull() const { return second.IsNull(); }
+                        bool IsScalar() const { return second.IsScalar(); }
+                        bool IsMap() const { return second.IsMap(); }
+                        bool IsSequence() const { return second.IsSequence(); }
+                        std::size_t size() const { return second.size(); }
+
+                        template<typename T>
+                        T as() const
+                        {
+                                return second.template as<T>();
+                        }
+
+                        Node operator[](std::string_view key) const { return second[key]; }
+                        Node operator[](std::size_t index) const { return second[index]; }
+                        std::string Scalar() const { return second.Scalar(); }
+
+                        operator Node() const { return second; }
+                };
+
+                using difference_type = std::ptrdiff_t;
+                using iterator_category = std::forward_iterator_tag;
+
+                const_iterator() = default;
+
+                static const_iterator MakeMapIterator(const Impl* owner,
+                        std::map<std::string, Node>::const_iterator it,
+                        std::map<std::string, Node>::const_iterator end)
+                {
+                        const_iterator iter;
+                        iter.m_owner = owner;
+                        iter.m_isSequence = false;
+                        iter.m_mapIt = it;
+                        iter.m_mapEnd = end;
+                        return iter;
+                }
+
+                static const_iterator MakeSequenceIterator(const Impl* owner,
+                        std::vector<Node>::const_iterator it,
+                        std::vector<Node>::const_iterator end)
+                {
+                        const_iterator iter;
+                        iter.m_owner = owner;
+                        iter.m_isSequence = true;
+                        iter.m_seqIt = it;
+                        iter.m_seqEnd = end;
+                        return iter;
+                }
+
+                value_type operator*() const
+                {
+                        if (!m_owner)
+                                return {};
+
+                        if (m_isSequence)
+                        {
+                                value_type value;
+                                value.second = (m_seqIt != m_seqEnd) ? *m_seqIt : Node();
+                                return value;
+                        }
+
+                        return value_type{ Key{ m_mapIt->first }, m_mapIt->second };
+                }
+
+                const_iterator& operator++()
+                {
+                        if (!m_owner)
+                                return *this;
+
+                        if (m_isSequence)
+                        {
+                                if (m_seqIt != m_seqEnd)
+                                        ++m_seqIt;
+                        }
+                        else
+                        {
+                                if (m_mapIt != m_mapEnd)
+                                        ++m_mapIt;
+                        }
+                        return *this;
+                }
+
+                bool operator==(const const_iterator& other) const
+                {
+                        if (m_owner != other.m_owner)
+                                return false;
+                        if (m_isSequence != other.m_isSequence)
+                                return false;
+
+                        if (!m_owner)
+                                return true;
+
+                        if (m_isSequence)
+                                return m_seqIt == other.m_seqIt;
+
+                        return m_mapIt == other.m_mapIt;
+                }
+
+                bool operator!=(const const_iterator& other) const
+                {
+                        return !(*this == other);
+                }
+
+        private:
+                const Impl* m_owner{ nullptr };
+                bool m_isSequence{ false };
+                std::map<std::string, Node>::const_iterator m_mapIt{};
+                std::map<std::string, Node>::const_iterator m_mapEnd{};
+                std::vector<Node>::const_iterator m_seqIt{};
+                std::vector<Node>::const_iterator m_seqEnd{};
+        };
+
+        const_iterator begin() const;
+        const_iterator end() const;
+
+        Type GetType() const { return m_data->type; }
+
+private:
+        struct Impl
+        {
+                Type type{ Type::Null };
+                std::string scalar{};
+                std::map<std::string, Node> map{};
+                std::vector<Node> sequence{};
+                EmitterStyle style{ EmitterStyle::Block };
+        };
+
+        std::shared_ptr<Impl> m_data;
+
+        void ensure_map();
+        void ensure_sequence();
+        void ensure_scalar();
+        void set_scalar(std::string value);
+
+        static std::string to_string(long long value)
+        {
+                return std::to_string(value);
+        }
+
+        static std::string to_string(unsigned long long value)
+        {
+                return std::to_string(value);
+        }
+
+        static std::string to_string(long double value)
+        {
+                std::ostringstream oss;
+                oss << value;
+                return oss.str();
+        }
+
+        template<typename T>
+        static std::string to_string(T value)
+        {
+                if constexpr (std::is_same_v<T, bool>)
+                {
+                        return value ? "true" : "false";
+                }
+                else if constexpr (std::is_floating_point_v<T>)
+                {
+                        std::ostringstream oss;
+                        oss << value;
+                        return oss.str();
+                }
+                else if constexpr (std::is_integral_v<T>)
+                {
+                        if constexpr (std::is_signed_v<T>)
+                                return std::to_string(static_cast<long long>(value));
+                        else
+                                return std::to_string(static_cast<unsigned long long>(value));
+                }
+                else
+                {
+                        std::ostringstream oss;
+                        oss << value;
+                        return oss.str();
+                }
+        }
+
+        static std::string trim(std::string_view value)
+        {
+                        auto begin = value.find_first_not_of(" \t\r\n");
+                        if (begin == std::string_view::npos)
+                                return {};
+                        auto end = value.find_last_not_of(" \t\r\n");
+                        return std::string(value.substr(begin, end - begin + 1));
+        }
+
+        static void parse_integer(const std::string& input, long long& out)
+        {
+                std::istringstream iss(input);
+                iss >> out;
+                if (!iss)
+                        throw std::runtime_error("Invalid integer scalar: " + input);
+        }
+
+        static void parse_unsigned(const std::string& input, unsigned long long& out)
+        {
+                std::istringstream iss(input);
+                iss >> out;
+                if (!iss)
+                        throw std::runtime_error("Invalid unsigned scalar: " + input);
+        }
+
+        static void parse_floating(const std::string& input, long double& out)
+        {
+                std::istringstream iss(input);
+                iss >> out;
+                if (!iss)
+                        throw std::runtime_error("Invalid floating scalar: " + input);
+        }
+
+        friend Node detail::from_ryml(const ryml::ConstNodeRef& ref);
+        friend void detail::to_ryml(const Node& node, ryml::NodeRef ref);
+};
+
+namespace detail
+{
+
+inline Node from_ryml(const ryml::ConstNodeRef& ref)
+{
+        Node node;
+
+        if (ref.is_map())
+        {
+                node.ensure_map();
+                if (ref.style() == ryml::FLOW_STYLE)
+                        node.SetStyle(EmitterStyle::Flow);
+                for (auto child : ref.children())
+                {
+                        std::string key = child.key().str();
+                        node[key] = from_ryml(child);
+                }
+        }
+        else if (ref.is_seq())
+        {
+                node.ensure_sequence();
+                if (ref.style() == ryml::FLOW_STYLE)
+                        node.SetStyle(EmitterStyle::Flow);
+                for (auto child : ref.children())
+                {
+                        node.push_back(from_ryml(child));
+                }
+        }
+        else if (ref.has_val())
+        {
+                node.ensure_scalar();
+                node.m_data->scalar = ref.val().str();
+        }
+        else
+        {
+                node.m_data->type = Node::Type::Null;
+        }
+
+        return node;
+}
+
+inline void to_ryml(const Node& node, ryml::NodeRef ref)
+{
+        switch (node.GetType())
+        {
+        case Node::Type::Null:
+                ref |= ryml::VAL;
+                ref << ryml::Null{};
+                break;
+        case Node::Type::Scalar:
+                ref |= ryml::VAL;
+                ref << node.m_data->scalar;
+                break;
+        case Node::Type::Map:
+                ref |= ryml::MAP;
+                if (node.GetStyle() == EmitterStyle::Flow)
+                        ref.set_style(ryml::FLOW_STYLE);
+                for (const auto& kv : node.m_data->map)
+                {
+                        ryml::NodeRef child = ref.append_child();
+                        child.set_key(ryml::to_csubstr(kv.first));
+                        to_ryml(kv.second, child);
+                }
+                break;
+        case Node::Type::Sequence:
+                ref |= ryml::SEQ;
+                if (node.GetStyle() == EmitterStyle::Flow)
+                        ref.set_style(ryml::FLOW_STYLE);
+                for (const auto& childNode : node.m_data->sequence)
+                {
+                        ryml::NodeRef child = ref.append_child();
+                        to_ryml(childNode, child);
+                }
+                break;
+        }
+}
+
+} // namespace detail
+
+inline Node::Node()
+        : m_data(std::make_shared<Impl>())
+{
+}
+
+inline std::size_t Node::size() const
+{
+        if (IsMap())
+                return m_data->map.size();
+        if (IsSequence())
+                return m_data->sequence.size();
+        return 0;
+}
+
+inline void Node::ensure_map()
+{
+        if (m_data->type != Type::Map)
+        {
+                m_data->type = Type::Map;
+                m_data->map.clear();
+                m_data->sequence.clear();
+                m_data->scalar.clear();
+        }
+}
+
+inline void Node::ensure_sequence()
+{
+        if (m_data->type != Type::Sequence)
+        {
+                m_data->type = Type::Sequence;
+                m_data->sequence.clear();
+                m_data->map.clear();
+                m_data->scalar.clear();
+        }
+}
+
+inline void Node::ensure_scalar()
+{
+        if (m_data->type != Type::Scalar)
+        {
+                m_data->type = Type::Scalar;
+                m_data->scalar.clear();
+                m_data->map.clear();
+                m_data->sequence.clear();
+        }
+}
+
+inline void Node::set_scalar(std::string value)
+{
+        ensure_scalar();
+        m_data->scalar = std::move(value);
+}
+
+inline Node& Node::operator[](std::string_view key)
+{
+        ensure_map();
+        auto& child = m_data->map[std::string(key)];
+        return child;
+}
+
+inline Node Node::operator[](std::string_view key) const
+{
+        if (!IsMap())
+                return Node();
+        auto it = m_data->map.find(std::string(key));
+        if (it == m_data->map.end())
+                return Node();
+        return it->second;
+}
+
+inline Node& Node::operator[](std::size_t index)
+{
+        ensure_sequence();
+        if (index >= m_data->sequence.size())
+                m_data->sequence.resize(index + 1);
+        return m_data->sequence[index];
+}
+
+inline Node Node::operator[](std::size_t index) const
+{
+        if (!IsSequence() || index >= m_data->sequence.size())
+                return Node();
+        return m_data->sequence[index];
+}
+
+inline Node& Node::operator=(const char* value)
+{
+        set_scalar(value ? std::string(value) : std::string{});
+        return *this;
+}
+
+inline Node& Node::operator=(const std::string& value)
+{
+        set_scalar(value);
+        return *this;
+}
+
+inline Node& Node::operator=(std::string_view value)
+{
+        set_scalar(std::string(value));
+        return *this;
+}
+
+inline void Node::push_back(const Node& node)
+{
+        ensure_sequence();
+        m_data->sequence.push_back(node);
+}
+
+inline Node::const_iterator Node::begin() const
+{
+        if (IsMap())
+                return const_iterator::MakeMapIterator(m_data.get(), m_data->map.begin(), m_data->map.end());
+        if (IsSequence())
+                return const_iterator::MakeSequenceIterator(m_data.get(), m_data->sequence.begin(), m_data->sequence.end());
+        return const_iterator{};
+}
+
+inline Node::const_iterator Node::end() const
+{
+        if (IsMap())
+                return const_iterator::MakeMapIterator(m_data.get(), m_data->map.end(), m_data->map.end());
+        if (IsSequence())
+                return const_iterator::MakeSequenceIterator(m_data.get(), m_data->sequence.end(), m_data->sequence.end());
+        return const_iterator{};
+}
+
+inline Node Load(const std::string& contents)
+{
+        ryml::Tree tree = ryml::parse_in_arena(ryml::to_csubstr(contents));
+        return detail::from_ryml(tree.crootref());
+}
+
+inline Node LoadFile(const std::string& path)
+{
+        std::ifstream file(path, std::ios::binary);
+        if (!file.is_open())
+        {
+                throw std::runtime_error("Failed to open YAML file: " + path);
+        }
+        std::stringstream buffer;
+        buffer << file.rdbuf();
+        return Load(buffer.str());
+}
+
+inline std::string Dump(const Node& node)
+{
+        ryml::Tree tree;
+        detail::to_ryml(node, tree.rootref());
+        return ryml::emitrs_yaml<std::string>(tree);
+}
+
+} // namespace YAML
+


### PR DESCRIPTION
## Summary
- add a rapidyaml-backed YAML::Node compatibility shim so reflection can operate without yaml-cpp
- adjust the inspector save path to emit YAML through the new Dump helper
- document rapidyaml as the engine's YAML dependency

## Testing
- not run (not available in this environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691132347d30832d84b6ecea5d598205)