### PR TITLE
Add managed CSharpScriptComponent wrapper and bindings

### DIFF
--- a/Assembly-CSharp/Assembly-CSharp/Assembly-CSharp/Class/CSharpScriptComponent.cs
+++ b/Assembly-CSharp/Assembly-CSharp/Assembly-CSharp/Class/CSharpScriptComponent.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace CreatorEngine
+{
+    public sealed class CSharpScriptComponent : Component
+    {
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern string ICall_GetScriptName(IntPtr self);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern string ICall_GetScriptGuid(IntPtr self);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern bool ICall_HasManagedInstance(IntPtr self);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern uint ICall_GetBehaviorHandle(IntPtr self);
+
+        public string ScriptName => ICall_GetScriptName(m_NativePtr);
+
+        public string ScriptGuid => ICall_GetScriptGuid(m_NativePtr);
+
+        public bool HasManagedInstance => ICall_HasManagedInstance(m_NativePtr);
+
+        public uint BehaviorHandle => ICall_GetBehaviorHandle(m_NativePtr);
+    }
+}

--- a/ScriptBinder/CSharpScriptComponent_Binding.h
+++ b/ScriptBinder/CSharpScriptComponent_Binding.h
@@ -1,0 +1,68 @@
+#pragma once
+#ifndef UNUSE_MONO_LIB
+#include "FormIntPtr.h"
+#include "CSharpScriptComponent.h"
+
+#include <string>
+
+namespace
+{
+    inline MonoString* UTF8ToMono(const std::string& value)
+    {
+        return mono_string_new(mono_domain_get(), value.c_str());
+    }
+
+    extern "C"
+    {
+        static MonoString* ICall_CSharpScriptComponent_GetScriptName(MonoObject* _this, intptr_t nativePtr) noexcept
+        {
+            if (auto* self = FromIntPtr<CSharpScriptComponent>(_this, nativePtr))
+            {
+                return UTF8ToMono(self->GetScriptName());
+            }
+
+            return UTF8ToMono(std::string{});
+        }
+
+        static MonoString* ICall_CSharpScriptComponent_GetScriptGuid(MonoObject* _this, intptr_t nativePtr) noexcept
+        {
+            if (auto* self = FromIntPtr<CSharpScriptComponent>(_this, nativePtr))
+            {
+                FileGuid guid = self->GetScriptGuid();
+                return UTF8ToMono(guid.ToString());
+            }
+
+            return UTF8ToMono(std::string{});
+        }
+
+        static mono_bool ICall_CSharpScriptComponent_HasManagedInstance(MonoObject* _this, intptr_t nativePtr) noexcept
+        {
+            if (auto* self = FromIntPtr<CSharpScriptComponent>(_this, nativePtr))
+            {
+                return self->HasManagedInstance() ? 1 : 0;
+            }
+
+            return 0;
+        }
+
+        static uint32_t ICall_CSharpScriptComponent_GetBehaviorHandle(MonoObject* _this, intptr_t nativePtr) noexcept
+        {
+            if (auto* self = FromIntPtr<CSharpScriptComponent>(_this, nativePtr))
+            {
+                return self->GetBehaviorHandle();
+            }
+
+            return 0u;
+        }
+    }
+}
+
+inline void Register_CSharpScriptComponent_ICalls()
+{
+    mono_add_internal_call("CreatorEngine.CSharpScriptComponent::ICall_GetScriptName", (const void*)ICall_CSharpScriptComponent_GetScriptName);
+    mono_add_internal_call("CreatorEngine.CSharpScriptComponent::ICall_GetScriptGuid", (const void*)ICall_CSharpScriptComponent_GetScriptGuid);
+    mono_add_internal_call("CreatorEngine.CSharpScriptComponent::ICall_HasManagedInstance", (const void*)ICall_CSharpScriptComponent_HasManagedInstance);
+    mono_add_internal_call("CreatorEngine.CSharpScriptComponent::ICall_GetBehaviorHandle", (const void*)ICall_CSharpScriptComponent_GetBehaviorHandle);
+}
+
+#endif // !UNUSE_MONO_LIB

--- a/ScriptBinder/MonoManager.cpp
+++ b/ScriptBinder/MonoManager.cpp
@@ -5,6 +5,7 @@
 #include "GameObject_Binding.h"
 #include "Transform_Binding.h"
 #include "RectTransform_Binding.h"
+#include "CSharpScriptComponent_Binding.h"
 #include "CSharpScriptComponent.h"
 #include "GameObject.h"
 #include "Scene.h"
@@ -173,6 +174,7 @@ void MonoManager::RegisterInternalCalls()
     Register_Component_ICalls();
     Register_Transform_ICalls();
     Register_RectTransform_ICalls();
+    Register_CSharpScriptComponent_ICalls();
     // ...
 }
 

--- a/ScriptBinder/ScriptBinder.vcxproj
+++ b/ScriptBinder/ScriptBinder.vcxproj
@@ -315,6 +315,7 @@
     <ClInclude Include="Component_Binding.h" />
     <ClInclude Include="RectTransformComponent.h" />
     <ClInclude Include="RectTransform_Binding.h" />
+    <ClInclude Include="CSharpScriptComponent_Binding.h" />
     <ClInclude Include="CurvePoint.h" />
     <ClInclude Include="ScriptStringModule.h" />
     <ClInclude Include="SoundComponent.h" />

--- a/ScriptBinder/ScriptBinder.vcxproj.filters
+++ b/ScriptBinder/ScriptBinder.vcxproj.filters
@@ -691,6 +691,9 @@
     <ClInclude Include="RectTransform_Binding.h">
       <Filter>Managers\HotLoadSystem\MonoLibSystem\Test</Filter>
     </ClInclude>
+    <ClInclude Include="CSharpScriptComponent_Binding.h">
+      <Filter>Managers\HotLoadSystem\MonoLibSystem\Test</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="GameObject.inl">


### PR DESCRIPTION
## Summary
- add a managed `CSharpScriptComponent` wrapper to the Assembly-CSharp project so scripts can access engine script components
- expose script component metadata through new internal calls registered by `MonoManager`
- register the binding header in the ScriptBinder project configuration files

## Testing
- command failed: `dotnet build Assembly-CSharp/Assembly-CSharp/Assembly-CSharp/Assembly-CSharp.csproj` (tool not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69114d8df8c8832d956c3a69093b497c)