### PR TITLE
Add MonoBehaviour lifecycle stubs to CSharpScriptComponent

### DIFF
--- a/Assembly-CSharp/Assembly-CSharp/Assembly-CSharp/Class/CSharpScriptComponent.cs
+++ b/Assembly-CSharp/Assembly-CSharp/Assembly-CSharp/Class/CSharpScriptComponent.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 
 namespace CreatorEngine
 {
-    public sealed class CSharpScriptComponent : Component
+    public class CSharpScriptComponent : Component
     {
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern string ICall_GetScriptName(IntPtr self);
@@ -24,5 +24,37 @@ namespace CreatorEngine
         public bool HasManagedInstance => ICall_HasManagedInstance(m_NativePtr);
 
         public uint BehaviorHandle => ICall_GetBehaviorHandle(m_NativePtr);
+
+        protected virtual void Awake()
+        {
+        }
+
+        protected virtual void OnEnable()
+        {
+        }
+
+        protected virtual void Start()
+        {
+        }
+
+        protected virtual void FixedUpdate(float fixedDeltaTime)
+        {
+        }
+
+        protected virtual void Update(float deltaTime)
+        {
+        }
+
+        protected virtual void LateUpdate(float deltaTime)
+        {
+        }
+
+        protected virtual void OnDisable()
+        {
+        }
+
+        protected virtual void OnDestroy()
+        {
+        }
     }
 }


### PR DESCRIPTION
## Summary
- allow scripts to derive from `CSharpScriptComponent`
- add virtual lifecycle hooks that correspond to scene event delegates

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691150076988832db0f352a6a19d6045)