### PR TITLE
Generate ScriptBinder API markdown documentation

### DIFF
--- a/API_DOCS/AIManager.md
+++ b/API_DOCS/AIManager.md
@@ -1,0 +1,20 @@
+# AIManager
+
+**Header:** `ScriptBinder/AIManager.h`
+
+**Inheritance:** `: public Singleton<AIManager>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `BlackBoard* CreateBlackBoard(const std::string& aiName);`
+- `void RemoveBlackBoard(const std::string& aiName);`
+- `void RegisterAIComponent(GameObject* gameObject, IAIComponent* aiComponent);`
+- `void UnRegisterAIComponent(GameObject* gameObject, IAIComponent* aiComponent);`
+- `void InternalAIUpdate(float deltaSeconds);`
+- `BT::BTNode::NodePtr CreateNode(std::string_view nodeName);`
+- `void ClearTreeInAIComponent();`
+- `void InitalizeBehaviorTreeSystem();`
+
+## Public Properties
+- (none)

--- a/API_DOCS/AIType.md
+++ b/API_DOCS/AIType.md
@@ -1,0 +1,11 @@
+# AIType
+
+**Header:** `ScriptBinder/IAIComponent.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/ActionMap.md
+++ b/API_DOCS/ActionMap.md
@@ -1,0 +1,23 @@
+# ActionMap
+
+**Header:** `ScriptBinder/ActionMap.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `ActionMap() = default;`
+- `~ActionMap();`
+- `InputAction* AddAction();`
+- `void AddButtonAction(std::string name, size_t _playerindex, InputType _inputType, size_t _key, KeyState _state, std::function<void()> _action);`
+- `void AddButtonAction(std::string name, size_t _playerindex, InputType _inputType, size_t _key, KeyState _state, void (*_action)());`
+- `void AddValueAction(std::string name, size_t _playerindex, InputValueType _inputValueType, InputType _inputType, std::vector<size_t> _keys, std::function<void(Mathf::Vector2)> _action);`
+- `void AddValueAction(std::string name, size_t _playerindex, InputValueType _inputValueType, InputType _inputType, std::vector<size_t> _keys, std::function<void(float)> _action);`
+- `void CheckAction();`
+- `void CheckAction(int playerIndex,void* instance, const Meta::Type* type);`
+- `void InvokeAction(void* instance, const Meta::Type* type, const std::string& methodName, const std::vector<std::any>& args);`
+- `void DeleteAction(const std::string& name);`
+- `InputAction* FindAction(const std::string& name);`
+
+## Public Properties
+- `std::string m_name;`
+- `std::vector<InputAction*> m_actions;`

--- a/API_DOCS/ActionNode.md
+++ b/API_DOCS/ActionNode.md
@@ -1,0 +1,16 @@
+# ActionNode
+
+**Header:** `ScriptBinder/BTHeader.h`
+
+**Inheritance:** `: public BTNode`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `using ActionFunc = std::function<NodeStatus(float, BlackBoard&)>;`
+- `ActionNode() = default;`
+- `~ActionNode() override = default;`
+- `NodeStatus Tick(float deltatime, BlackBoard& blackBoard) override abstract;`
+
+## Public Properties
+- (none)

--- a/API_DOCS/ActionType.md
+++ b/API_DOCS/ActionType.md
@@ -1,0 +1,11 @@
+# ActionType
+
+**Header:** `ScriptBinder/InputAction.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/AnchorPreset.md
+++ b/API_DOCS/AnchorPreset.md
@@ -1,0 +1,11 @@
+# AnchorPreset
+
+**Header:** `ScriptBinder/AnchorPreset.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/AniBehavior.md
+++ b/API_DOCS/AniBehavior.md
@@ -1,0 +1,12 @@
+# AniBehavior
+
+**Header:** `ScriptBinder/AniBehavior.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `AniBehavior() = default;`
+- `virtual ~AniBehavior() = default;`
+
+## Public Properties
+- (none)

--- a/API_DOCS/AniTransition.md
+++ b/API_DOCS/AniTransition.md
@@ -1,0 +1,29 @@
+# AniTransition
+
+**Header:** `ScriptBinder/AniTransition.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `AniTransition() = default;`
+- `AniTransition(AnimationState* _curState, AnimationState* _nextState);`
+- `~AniTransition();`
+- `void DeleteCondition(int _index);`
+- `void SetCurState(std::string _curStateName);`
+- `void SetCurState(AnimationState* _curState);`
+- `void SetNextState(std::string _nextStateName);`
+- `void SetNextState(AnimationState* _nextStat);`
+- `std::string GetCurState();`
+- `std::string GetNextState();`
+- `bool CheckTransiton(bool isBlend = false);`
+- `nlohmann::json Serialize();`
+- `AniTransition Deserialize();`
+- `std::vector<TransCondition> GetConditions();`
+
+## Public Properties
+- `std::string m_name = "NoName";`
+- `AnimationState* curState = nullptr;`
+- `AnimationState* nextState = nullptr;`
+- `float exitTime = 0.1f;`
+- `float blendTime = 0.2f;`
+- `bool hasExitTime = false;`

--- a/API_DOCS/AnimationBehviourFatory.md
+++ b/API_DOCS/AnimationBehviourFatory.md
@@ -1,0 +1,13 @@
+# AnimationBehviourFatory
+
+**Header:** `ScriptBinder/AnimationBehviourFatory.h`
+
+**Inheritance:** `: public Singleton<AnimationBehviourFatory>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `std::unordered_map<std::string, std::function<AniBehavior* ()>> m_aniFactoryMap;`
+
+## Public Properties
+- (none)

--- a/API_DOCS/AnimationController.md
+++ b/API_DOCS/AnimationController.md
@@ -1,0 +1,51 @@
+# AnimationController
+
+**Header:** `ScriptBinder/AnimationController.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `AnimationController() = default;`
+- `~AnimationController();`
+- `bool BlendingAnimation(float tick);`
+- `void SetCurState(std::string stateName);`
+- `void SetNextState(std::string stateName);`
+- `std::shared_ptr<AniTransition> CheckTransition();`
+- `void UpdateState();`
+- `void Update(float tick);`
+- `int GetAnimatonIndexformState(std::string stateName);`
+- `std::shared_ptr<AnimationState> GetAniState();`
+- `AnimationState* CreateState(const std::string& stateName, int animationIndex,bool isAny = false);`
+- `std::shared_ptr<AnimationState> CreateState_UI();`
+- `void DeleteState(std::string stateName);`
+- `void DeleteTransiton(const std::string& fromStateName, const std::string& toStateName);`
+- `AnimationState* FindState(std::string stateName);`
+- `AniTransition* CreateTransition(const std::string& curStateName, const std::string& nextStateName);`
+- `void CreateMask();`
+- `void ReCreateMask(AvatarMask* mask);`
+- `void DeleteAvatarMask();`
+- `nlohmann::json Serialize();`
+- `void Deserialize();`
+- `void SetUseLayer(bool _useLayer);`
+
+## Public Properties
+- `std::string name = "None";`
+- `AnimationState* m_curState = nullptr;`
+- `AnimationState* m_nextState = nullptr;`
+- `std::vector<std::shared_ptr<AnimationState>> StateVec;`
+- `std::unordered_map<std::string, std::weak_ptr<AnimationState>> m_nameToState;`
+- `std::set<std::string> StateNameSet;`
+- `NodeEditor* m_nodeEditor;`
+- `std::shared_ptr<AnimationState> m_anyState;`
+- `float m_timeElapsed;`
+- `float m_nextTimeElapsed;`
+- `float curAnimationProgress = 0.f;`
+- `float preCurAnimationProgress = 0.f;`
+- `float nextAnimationProgress = 0.f;`
+- `float preNextAnimationProgress = 0.f;`
+- `bool needBlend = false;`
+- `bool m_isBlend = false;`
+- `bool useController = true;`
+- `bool m_useLayer = true;`
+- `bool useMask = false;`
+- `bool endAnimation = false;`

--- a/API_DOCS/AnimationState.md
+++ b/API_DOCS/AnimationState.md
@@ -1,0 +1,26 @@
+# AnimationState
+
+**Header:** `ScriptBinder/AnimationState.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `AnimationState();`
+- `~AnimationState();`
+- `AnimationState(AnimationController* Owner, std::string name);`
+- `std::vector<AniTransition*> FindTransitions(const std::string& toStateName);`
+- `void SetBehaviour(std::string name, bool isReload = false);`
+- `void UpdateAnimationSpeed();`
+- `nlohmann::json Serialize();`
+- `AnimationState Deserialize();`
+
+## Public Properties
+- `std::vector<std::shared_ptr<AniTransition>> Transitions;`
+- `int index =0;`
+- `int AnimationIndex = 0;`
+- `float animationSpeed = 1;`
+- `float multiplerAnimationSpeed = 1;`
+- `std::string animationSpeedParameterName = "None";`
+- `float m_animationTimeElapsed = 0;`
+- `bool m_isAny = false;`
+- `bool useMultipler = false;`

--- a/API_DOCS/Animator.md
+++ b/API_DOCS/Animator.md
@@ -1,0 +1,43 @@
+# Animator
+
+**Header:** `ScriptBinder/Animator.h`
+
+**Inheritance:** `: public Component, public RegistableEvent<Animator>, public std::enable_shared_from_this<Animator>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `void Awake() override;`
+- `void Update(float tick) override;`
+- `void OnDestroy() override;`
+- `void SetAnimation(int index);`
+- `void UpdateAnimation();`
+- `void CreateController(std::string name);`
+- `std::shared_ptr<AnimationController> CreateController_UI();`
+- `std::shared_ptr<AnimationController> CreateController_UINoAni();`
+- `void DeleteController(int index);`
+- `void DeleteController(std::string controllerName);`
+- `AnimationController* GetController(std::string name);`
+- `void SerializeControllers(std::string _jsonName);`
+- `void DeserializeControllers(std::string _filename);`
+- `void SetUseLayer(int layerindex,bool _useLayer);`
+- `GameObject* FindBoneRecursive(GameObject* parent, const std::string& boneName);`
+- `Socket* MakeSocket(std::string_view socketName,std::string_view boneName, GameObject* object);`
+- `Socket* FindSocket(std::string_view socketName);`
+- `void ClearControllersAndParams();`
+- `void AddParameter(const std::string valuename, T value, ValueType vType);`
+- `void DeleteParameter(int index);`
+- `ConditionParameter* AddDefaultParameter(ValueType vType);`
+- `void SetParameter(const std::string valuename, T Value);`
+- `ConditionParameter* FindParameter(std::string valueName);`
+
+## Public Properties
+- `float blendT = 0;`
+- `int nextAnimIndex = -1;`
+- `XMMATRIX blendtransform;`
+- `std::vector<Socket*> socketvec;`
+- `std::vector<ConditionParameter*> Parameters;`
+- `std::mutex m_paramMutex;`
+- `bool m_isBlend = false;`
+- `float m_stopTimer = 0.f;`
+- `float m_stopDuration = 0.f;`

--- a/API_DOCS/ArticulationData.md
+++ b/API_DOCS/ArticulationData.md
@@ -1,0 +1,12 @@
+# ArticulationData
+
+**Header:** `ScriptBinder/ArticulationData.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `ArticulationData() = default;`
+- `~ArticulationData() = default;`
+
+## Public Properties
+- (none)

--- a/API_DOCS/ArticulationLoader.md
+++ b/API_DOCS/ArticulationLoader.md
@@ -1,0 +1,13 @@
+# ArticulationLoader
+
+**Header:** `ScriptBinder/ArticulationLoader.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `void Save(const ArticulationData* data, const std::string& path);`
+- `ArticulationData* Load(const std::string& path);`
+- `ArticulationData* Load(const std::string& path,unsigned int& numbuer);`
+
+## Public Properties
+- (none)

--- a/API_DOCS/AvatarMask.md
+++ b/API_DOCS/AvatarMask.md
@@ -1,0 +1,20 @@
+# AvatarMask
+
+**Header:** `ScriptBinder/AvatarMask.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `AvatarMask() = default;`
+- `~AvatarMask();`
+- `bool IsBoneEnabled(BoneRegion region);`
+- `void ReCreateMask(AvatarMask* _otherMask);`
+- `bool IsBoneEnabled(const std::string& name);`
+- `BoneMask* MakeBoneMask(Bone* Bone);`
+
+## Public Properties
+- `std::vector<BoneMask*> m_BoneMasks;`
+- `bool isHumanoid = true;`
+- `bool useAll = false;`
+- `bool useUpper = true;`
+- `bool useLower = true;`

--- a/API_DOCS/BTNode.md
+++ b/API_DOCS/BTNode.md
@@ -1,0 +1,16 @@
+# BTNode
+
+**Header:** `ScriptBinder/BTHeader.h`
+
+**Inheritance:** `: public Managed::HeapObject`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `BTNode() = default;`
+- `virtual ~BTNode() = default;`
+- `virtual NodeStatus Tick(float deltatime,BlackBoard& blackBoard) = 0;`
+- `virtual BehaviorNodeType GetNodeType() const = 0;`
+
+## Public Properties
+- `using NodePtr = std::shared_ptr<BTNode>;`

--- a/API_DOCS/BehaviorNodeType.md
+++ b/API_DOCS/BehaviorNodeType.md
@@ -1,0 +1,11 @@
+# BehaviorNodeType
+
+**Header:** `ScriptBinder/BTEnum.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/BehaviorTreeComponent.md
+++ b/API_DOCS/BehaviorTreeComponent.md
@@ -1,0 +1,22 @@
+# BehaviorTreeComponent
+
+**Header:** `ScriptBinder/BehaviorTreeComponent.h`
+
+**Inheritance:** `: 
+	public Component, public IAIComponent, public RegistableEvent<BehaviorTreeComponent>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `void Initialize() override;`
+- `void Awake() override;`
+- `void InternalAIUpdate(float deltaSecond) override;`
+- `void OnDestroy() override;`
+- `BlackBoard* GetBlackBoard();`
+- `void GraphToBuild();`
+
+## Public Properties
+- `std::string name;`
+- `std::string blackBoardName;`
+- `FileGuid m_BehaviorTreeGuid;`
+- `FileGuid m_BlackBoardGuid;`

--- a/API_DOCS/BlackBoard.md
+++ b/API_DOCS/BlackBoard.md
@@ -1,0 +1,36 @@
+# BlackBoard
+
+**Header:** `ScriptBinder/Blackboard.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `void SetValueAsBool(const std::string& key, bool value);`
+- `void SetValueAsInt(const std::string& key, int value);`
+- `void SetValueAsFloat(const std::string& key, float value);`
+- `void SetValueAsString(const std::string& key, const std::string& value);`
+- `void SetValueAsVector2(const std::string& key, const Mathf::Vector2& value);`
+- `void SetValueAsVector3(const std::string& key, const Mathf::Vector3& value);`
+- `void SetValueAsVector4(const std::string& key, const Mathf::Vector4& value);`
+- `void SetValueAsGameObject(const std::string& key, const std::string& objectName);`
+- `void SetValueAsTransform(const std::string& key, const std::string& transformPath);`
+- `bool GetValueAsBool(const std::string& key) const;`
+- `int GetValueAsInt(const std::string& key) const;`
+- `float GetValueAsFloat(const std::string& key) const;`
+- `const std::string& GetValueAsString(const std::string& key) const;`
+- `const Mathf::Vector2& GetValueAsVector2(const std::string& key) const;`
+- `const Mathf::Vector3& GetValueAsVector3(const std::string& key) const;`
+- `const Mathf::Vector4& GetValueAsVector4(const std::string& key) const;`
+- `GameObject* GetValueAsGameObject(const std::string& key) const;`
+- `const Transform& GetValueAsTransform(const std::string& key) const;`
+- `void AddKey(const std::string& key, const BlackBoardType& type);`
+- `bool HasKey(const std::string& key) const;`
+- `BlackBoardType GetType(const std::string& key) const;`
+- `void RemoveKey(const std::string& key);`
+- `void RenameKey(const std::string& curKey, const std::string& newKey);`
+- `void Clear();`
+- `void Serialize(std::string_view name);`
+- `void Deserialize(std::string_view name);`
+
+## Public Properties
+- (none)

--- a/API_DOCS/BlackBoardType.md
+++ b/API_DOCS/BlackBoardType.md
@@ -1,0 +1,11 @@
+# BlackBoardType
+
+**Header:** `ScriptBinder/BlackBoardEnum.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/BoneMask.md
+++ b/API_DOCS/BoneMask.md
@@ -1,0 +1,13 @@
+# BoneMask
+
+**Header:** `ScriptBinder/BoneMask.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `BoneMask() = default;`
+
+## Public Properties
+- `std::string boneName;`
+- `std::vector<BoneMask*> m_children;`
+- `bool isEnabled = true;`

--- a/API_DOCS/BoxColliderComponent.md
+++ b/API_DOCS/BoxColliderComponent.md
@@ -1,0 +1,21 @@
+# BoxColliderComponent
+
+**Header:** `ScriptBinder/BoxColliderComponent.h`
+
+**Inheritance:** `: public Component, public ICollider, public RegistableEvent<BoxColliderComponent>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `virtual ~BoxColliderComponent() = default;`
+- `void SetPositionOffset(DirectX::SimpleMath::Vector3 pos) override;`
+- `DirectX::SimpleMath::Vector3 GetPositionOffset() override;`
+- `void SetRotationOffset(DirectX::SimpleMath::Quaternion rotation) override;`
+- `DirectX::SimpleMath::Quaternion GetRotationOffset() override;`
+
+## Public Properties
+- `float staticFriction = 0.5f;`
+- `float dynamicFriction = 0.4f;`
+- `float restitution = 0.3f;`
+- `float density = 10.0f;`
+- `BoxColliderInfo m_Info;`

--- a/API_DOCS/CSharpScriptComponent.md
+++ b/API_DOCS/CSharpScriptComponent.md
@@ -1,0 +1,13 @@
+# CSharpScriptComponent
+
+**Header:** `ScriptBinder/CSharpScriptComponent.h`
+
+**Inheritance:** `: public Component`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/CameraComponent.md
+++ b/API_DOCS/CameraComponent.md
@@ -1,0 +1,13 @@
+# CameraComponent
+
+**Header:** `ScriptBinder/CameraComponent.h`
+
+**Inheritance:** `: public Component, public RegistableEvent<CameraComponent>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `virtual ~CameraComponent() = default;`
+
+## Public Properties
+- (none)

--- a/API_DOCS/Canvas.md
+++ b/API_DOCS/Canvas.md
@@ -1,0 +1,21 @@
+# Canvas
+
+**Header:** `ScriptBinder/Canvas.h`
+
+**Inheritance:** `: public Component, public RegistableEvent<Canvas>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `Canvas();`
+- `~Canvas() = default;`
+- `void OnDestroy() override;`
+- `void AddUIObject(std::shared_ptr<GameObject> obj);`
+- `virtual void Update(float tick) override;`
+- `std::weak_ptr<GameObject> GetFrontUIObject();`
+
+## Public Properties
+- `int PreCanvasOrder = 0;`
+- `int CanvasOrder = 0;`
+- `std::vector<std::weak_ptr<GameObject>> UIObjs;`
+- `std::string CanvasName = "Canvas";`

--- a/API_DOCS/CapsuleColliderComponent.md
+++ b/API_DOCS/CapsuleColliderComponent.md
@@ -1,0 +1,22 @@
+# CapsuleColliderComponent
+
+**Header:** `ScriptBinder/CapsuleColliderComponent.h`
+
+**Inheritance:** `: public Component, public ICollider, public RegistableEvent<CapsuleColliderComponent>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `virtual ~CapsuleColliderComponent() = default;`
+- `void OnTriggerEnter(ICollider* other) override;`
+- `void OnTriggerStay(ICollider* other) override;`
+- `void OnTriggerExit(ICollider* other) override;`
+- `void OnCollisionEnter(ICollider* other) override;`
+- `void OnCollisionStay(ICollider* other) override;`
+- `void OnCollisionExit(ICollider* other) override;`
+
+## Public Properties
+- `float staticFriction = 0.5f;`
+- `float dynamicFriction = 0.4f;`
+- `float restitution = 0.3f;`
+- `float density = 10.0f;`

--- a/API_DOCS/ChannelType.md
+++ b/API_DOCS/ChannelType.md
@@ -1,0 +1,11 @@
+# ChannelType
+
+**Header:** `ScriptBinder/SoundDefinition.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/CharacterControllerComponent.md
+++ b/API_DOCS/CharacterControllerComponent.md
@@ -1,0 +1,29 @@
+# CharacterControllerComponent
+
+**Header:** `ScriptBinder/CharacterControllerComponent.h`
+
+**Inheritance:** `: public Component, public ICollider, public RegistableEvent<CharacterControllerComponent>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `void OnStart();`
+- `void OnFixedUpdate(float fixedDeltaTime);`
+- `void OnLateUpdate(float fixedDeltaTime);`
+- `void ForcedSetPosition(const DirectX::SimpleMath::Vector3& pos);`
+- `void SetAutomaticRotation(bool useAuto);`
+- `void TriggerForcedMove(const DirectX::SimpleMath::Vector3& initialVelocity, float duration=0.0f, Mathf::Easing::EaseType curveType = Mathf::Easing::EaseType::None);`
+- `void StopForcedMove();`
+- `bool IsInForcedMove() const;`
+- `void SetLookDirection(const DirectX::SimpleMath::Vector3& direction);`
+- `void ClearLookDirection();`
+
+## Public Properties
+- `float m_radius = 0.55f;`
+- `float m_height = 2.f;`
+- `float maxSpeed = 1.025f;`
+- `float acceleration = 1.0f;`
+- `float staticFriction = 0.4f;`
+- `float dynamicFriction = 0.1f;`
+- `float jumpSpeed = 0.05f;`
+- `float gravityWeight = 0.2f;`

--- a/API_DOCS/ClipDirection.md
+++ b/API_DOCS/ClipDirection.md
@@ -1,0 +1,13 @@
+# ClipDirection
+
+**Header:** `ScriptBinder/Navigation.h`
+
+**Inheritance:** `: std::uint8_t`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/Component.md
+++ b/API_DOCS/Component.md
@@ -1,0 +1,16 @@
+# Component
+
+**Header:** `ScriptBinder/Component.h`
+
+**Inheritance:** `: public Object`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `void SetOwner(GameObject* owner);`
+- `T* GetComponent();`
+- `T* GetComponentDynamicCast();`
+- `Component& GetComponent(HashedGuid typeof);`
+
+## Public Properties
+- (none)

--- a/API_DOCS/ComponentFactory.md
+++ b/API_DOCS/ComponentFactory.md
@@ -1,0 +1,14 @@
+# ComponentFactory
+
+**Header:** `ScriptBinder/ComponentFactory.h`
+
+**Inheritance:** `: public DLLCore::Singleton<ComponentFactory>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `void Initialize();`
+- `void LoadComponent(GameObject* obj, const MetaYml::detail::iterator_value& itNode, bool isEditorToGame = false);`
+
+## Public Properties
+- (none)

--- a/API_DOCS/CompositeNode.md
+++ b/API_DOCS/CompositeNode.md
@@ -1,0 +1,14 @@
+# CompositeNode
+
+**Header:** `ScriptBinder/BTHeader.h`
+
+**Inheritance:** `: public BTNode`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `CompositeNode() = default;`
+- `~CompositeNode() override = default;`
+
+## Public Properties
+- (none)

--- a/API_DOCS/ConditionDecoratorNode.md
+++ b/API_DOCS/ConditionDecoratorNode.md
@@ -1,0 +1,16 @@
+# ConditionDecoratorNode
+
+**Header:** `ScriptBinder/BTHeader.h`
+
+**Inheritance:** `: public DecoratorNode`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `using ConditionFunc = std::function<bool(float, const BlackBoard&)>;`
+- `ConditionDecoratorNode() = default;`
+- `~ConditionDecoratorNode() override = default;`
+- `virtual bool ConditionCheck(float deltatime, const BlackBoard& blackBoard) abstract;`
+
+## Public Properties
+- (none)

--- a/API_DOCS/ConditionNode.md
+++ b/API_DOCS/ConditionNode.md
@@ -1,0 +1,15 @@
+# ConditionNode
+
+**Header:** `ScriptBinder/BTHeader.h`
+
+**Inheritance:** `: public BTNode`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `ConditionNode() = default;`
+- `~ConditionNode() override = default;`
+- `virtual bool ConditionCheck(float deltatime, const BlackBoard& blackBoard) abstract;`
+
+## Public Properties
+- (none)

--- a/API_DOCS/ConditionParameter.md
+++ b/API_DOCS/ConditionParameter.md
@@ -1,0 +1,14 @@
+# ConditionParameter
+
+**Header:** `ScriptBinder/ConditionParameter.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `ConditionParameter() = default;`
+- `nlohmann::json Serialize();`
+- `void Deserialize();`
+
+## Public Properties
+- `std::string name = "None";`
+- `ValueType vType =ValueType::Float;`

--- a/API_DOCS/ConditionType.md
+++ b/API_DOCS/ConditionType.md
@@ -1,0 +1,11 @@
+# ConditionType
+
+**Header:** `ScriptBinder/ConditionParameter.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/DecalComponent.md
+++ b/API_DOCS/DecalComponent.md
@@ -1,0 +1,27 @@
+# DecalComponent
+
+**Header:** `ScriptBinder/DecalComponent.h`
+
+**Inheritance:** `: public Component, public RegistableEvent<DecalComponent>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `void Awake() override;`
+- `void Update(float deltaSeconds) override;`
+- `void OnDestroy() override;`
+- `void SetDecalTexture(const std::string_view& fileName);`
+- `void SetDecalTexture(const FileGuid& fileGuid);`
+- `void SetNormalTexture(const std::string_view& fileName);`
+- `void SetNormalTexture(const FileGuid& fileGuid);`
+- `void SetORMTexture(const std::string_view& fileName);`
+- `void SetORMTexture(const FileGuid& fileGuid);`
+
+## Public Properties
+- `uint32 sliceX = 1;`
+- `uint32 sliceY = 1;`
+- `int sliceNumber = 0;`
+- `float slicePerSeconds = 1.f;`
+- `float timer = 0.f;`
+- `bool useAnimation = false;`
+- `bool isLoop = true;`

--- a/API_DOCS/DecoratorNode.md
+++ b/API_DOCS/DecoratorNode.md
@@ -1,0 +1,14 @@
+# DecoratorNode
+
+**Header:** `ScriptBinder/BTHeader.h`
+
+**Inheritance:** `: public BTNode`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `DecoratorNode() = default;`
+- `~DecoratorNode() override = default;`
+
+## Public Properties
+- (none)

--- a/API_DOCS/Direction.md
+++ b/API_DOCS/Direction.md
@@ -1,0 +1,11 @@
+# Direction
+
+**Header:** `ScriptBinder/Navigation.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/EBodyType.md
+++ b/API_DOCS/EBodyType.md
@@ -1,0 +1,11 @@
+# EBodyType
+
+**Header:** `ScriptBinder/EBodyType.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/EForceMode.md
+++ b/API_DOCS/EForceMode.md
@@ -1,0 +1,11 @@
+# EForceMode
+
+**Header:** `ScriptBinder/EForceMode.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/EShapeType.md
+++ b/API_DOCS/EShapeType.md
@@ -1,0 +1,11 @@
+# EShapeType
+
+**Header:** `ScriptBinder/LinkData.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/EffectComponent.md
+++ b/API_DOCS/EffectComponent.md
@@ -1,0 +1,34 @@
+# EffectComponent
+
+**Header:** `ScriptBinder/EffectComponent.h`
+
+**Inheritance:** `: public Component, public RegistableEvent<EffectComponent>, public System::IInitializable, public std::enable_shared_from_this<EffectComponent>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `void Initialize() override;`
+- `void Update(float tick) override;`
+- `void OnDestroy() override;`
+- `void Apply();`
+- `void PlayPreview();`
+- `void StopEffect();`
+- `void PauseEffect();`
+- `void ResumeEffect();`
+- `void ChangeEffect(const std::string& newEffectName);`
+- `void PlayEffectByName(const std::string& effectName);`
+- `void SetLoop(bool loop);`
+- `void SetDuration(float duration);`
+- `void SetTimeScale(float timeScale);`
+- `void ForceFinishEffect();`
+
+## Public Properties
+- `std::string m_effectTemplateName = "Null";`
+- `float m_timeScale = 1.0f;`
+- `float m_duration = -1.0f;`
+- `bool m_isPlaying = false;`
+- `bool m_isPaused = false;`
+- `bool m_loop = true;`
+- `bool m_useAbsolutePosition = false;`
+- `float m_currentTime = 0;`
+- `std::string m_effectInstanceName;`

--- a/API_DOCS/FSMState.md
+++ b/API_DOCS/FSMState.md
@@ -1,0 +1,13 @@
+# FSMState
+
+**Header:** `ScriptBinder/FSMState.h`
+
+**Inheritance:** `: public IScriptedFSM`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `virtual ~FSMState() = default;`
+
+## Public Properties
+- (none)

--- a/API_DOCS/FoliageComponent.md
+++ b/API_DOCS/FoliageComponent.md
@@ -1,0 +1,25 @@
+# FoliageComponent
+
+**Header:** `ScriptBinder/FoliageComponent.h`
+
+**Inheritance:** `: public Component, public RegistableEvent<FoliageComponent>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `void Awake() override;`
+- `void Update(float deltaTime) override;`
+- `void OnDestroy() override;`
+- `void SaveFoliageAsset(const file::path& savePath);`
+- `void LoadFoliageAsset(FileGuid assetGuid);`
+- `void AddFoliageType(const FoliageType& type);`
+- `void RemoveFoliageType(uint32 typeID);`
+- `void AddFoliageInstance(const FoliageInstance& instance);`
+- `void RemoveFoliageInstance(size_t index);`
+- `void AddInstanceFromTerrain(TerrainComponent* terrain, const FoliageInstance& instance);`
+- `void AddRandomInstancesInBrush(TerrainComponent* terrain, const TerrainBrush& brush, uint32 typeID, int count);`
+- `void RemoveInstancesInBrush(TerrainComponent* terrain, const TerrainBrush& brush);`
+- `void UpdateFoliageCullingData(Camera* camera);`
+
+## Public Properties
+- (none)

--- a/API_DOCS/FoliageMode.md
+++ b/API_DOCS/FoliageMode.md
@@ -1,0 +1,11 @@
+# FoliageMode
+
+**Header:** `ScriptBinder/TerrainBuffers.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/FunctionRegistry.md
+++ b/API_DOCS/FunctionRegistry.md
@@ -1,0 +1,11 @@
+# FunctionRegistry
+
+**Header:** `ScriptBinder/FunctionRegistry.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/GameObject.md
+++ b/API_DOCS/GameObject.md
@@ -1,0 +1,57 @@
+# GameObject
+
+**Header:** `ScriptBinder/GameObject.h`
+
+**Inheritance:** `: public Object, public std::enable_shared_from_this<GameObject>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `static constexpr GameObject::Index INVALID_INDEX = std::numeric_limits<uint32_t>::max();`
+- `GameObject();`
+- `GameObject(Scene* scene, std::string_view name, GameObjectType type, GameObject::Index index, GameObject::Index parentIndex);`
+- `GameObject(Scene* scene, size_t instanceID, std::string_view name, GameObjectType type, GameObject::Index index, GameObject::Index parentIndex);`
+- `GameObject(GameObject&) = delete;`
+- `GameObject(GameObject&&) noexcept = default;`
+- `GameObject& operator=(GameObject&) = delete;`
+- `~GameObject() override = default;`
+- `const std::string& RemoveSuffixNumberTag() const;`
+- `void SetTag(std::string_view tag);`
+- `void SetLayer(std::string_view layer);`
+- `virtual void Destroy() override final;`
+- `std::shared_ptr<Component> AddComponent(const Meta::Type& type);`
+- `ModuleBehavior* AddScriptComponent(std::string_view scriptName);`
+- `std::shared_ptr<Component> GetComponent(const Meta::Type& type);`
+- `std::shared_ptr<Component> GetComponentByTypeID(uint32 id);`
+- `void RefreshComponentIdIndices();`
+- `void AddChild(GameObject* _objcet);`
+- `T* AddComponent();`
+- `T* AddComponent(Args&&... args);`
+- `T* GetComponent(uint32 id);`
+- `T* GetComponent();`
+- `T* GetComponentDynamicCast();`
+- `std::vector<T*> GetComponentsInChildren();`
+- `std::vector<T*> GetComponentsInchildrenDynamicCast();`
+- `bool HasComponent();`
+- `std::vector<T*> GetComponents();`
+- `void RemoveComponent(T* component);`
+- `void RemoveComponentIndex(uint32 id);`
+- `void RemoveComponentTypeID(uint32 typeID);`
+- `void RemoveScriptComponent(std::string_view scriptName);`
+- `void RemoveScriptComponent(ModuleBehavior* ptr);`
+- `void RemoveComponent(Meta::Type& type);`
+- `static GameObject* Find(std::string_view name);`
+- `static GameObject* FindIndex(GameObject::Index index);`
+- `static GameObject* FindInstanceID(const HashedGuid& guid);`
+- `static GameObject* FindAttachedID(const HashedGuid& guid);`
+- `GameObject* OwnerSceneFind(std::string_view name);`
+- `GameObject* OwnerSceneFindIndex(GameObject::Index index);`
+- `GameObject* OwnerSceneFindInstanceID(const HashedGuid& guid);`
+- `GameObject* OwnerSceneFindAttachedID(const HashedGuid& guid);`
+- `void SetEnabled(bool able) override final;`
+- `void SetCollisionType();`
+
+## Public Properties
+- `using Index = int;`
+- `uint32 m_collisionType = 0;`
+- `std::vector<GameObject::Index> m_childrenIndices;`

--- a/API_DOCS/GameObjectType.md
+++ b/API_DOCS/GameObjectType.md
@@ -1,0 +1,11 @@
+# GameObjectType
+
+**Header:** `ScriptBinder/GameObjectType.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/HotLoadSystem.md
+++ b/API_DOCS/HotLoadSystem.md
@@ -1,0 +1,32 @@
+# HotLoadSystem
+
+**Header:** `ScriptBinder/HotLoadSystem.h`
+
+**Inheritance:** `: public DLLCore::Singleton<HotLoadSystem>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `void Initialize();`
+- `void Shutdown();`
+- `bool IsScriptUpToDate();`
+- `void ReloadDynamicLibrary();`
+- `void ReplaceScriptComponent();`
+- `void ReplaceScriptComponentTargetScene(Scene* targetScene);`
+- `void CompileEvent();`
+- `void CreateScriptFile(std::string_view name);`
+- `void BindScriptEvents(ModuleBehavior* script, std::string_view name);`
+- `void UnbindScriptEvents(ModuleBehavior* script, std::string_view name);`
+- `void RegisterScriptReflection(std::string_view name, ModuleBehavior* script);`
+- `void UnRegisterScriptReflection(std::string_view name);`
+- `void RecollectScriptComponents(const std::vector<std::shared_ptr<GameObject>>& gameObjects);`
+- `void CreateActionNodeScript(std::string_view name);`
+- `void CreateConditionNodeScript(std::string_view name);`
+- `void CreateConditionDecoratorNodeScript(std::string_view name);`
+- `void CreateAniBehaviorScript(std::string_view name);`
+- `void CollectScriptComponent(GameObject* gameObject, size_t index, const std::string& name);`
+- `void UnCollectScriptComponent(GameObject* gameObject, size_t index, const std::string& name);`
+- `void ResetAniBehaviorPtr();`
+
+## Public Properties
+- (none)

--- a/API_DOCS/IAIComponent.md
+++ b/API_DOCS/IAIComponent.md
@@ -1,0 +1,12 @@
+# IAIComponent
+
+**Header:** `ScriptBinder/IAIComponent.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `virtual ~IAIComponent() = default;`
+- `virtual void Initialize() = 0;`
+
+## Public Properties
+- (none)

--- a/API_DOCS/IRegistableEvent.md
+++ b/API_DOCS/IRegistableEvent.md
@@ -1,0 +1,12 @@
+# IRegistableEvent
+
+**Header:** `ScriptBinder/IRegistableEvent.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `virtual ~IRegistableEvent();`
+- `virtual void RegisterOverriddenEvents(Scene* scene) = 0;`
+
+## Public Properties
+- (none)

--- a/API_DOCS/IScriptedFSM.md
+++ b/API_DOCS/IScriptedFSM.md
@@ -1,0 +1,14 @@
+# IScriptedFSM
+
+**Header:** `ScriptBinder/IScriptedFSM.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `virtual ~IScriptedFSM() = default;`
+- `virtual void Enter(BlackBoard& bb) = 0;`
+- `virtual void Update(BlackBoard& bb, float deltaTime) = 0;`
+- `virtual void Exit(BlackBoard& bb) = 0;`
+
+## Public Properties
+- (none)

--- a/API_DOCS/ISerializable.md
+++ b/API_DOCS/ISerializable.md
@@ -1,0 +1,14 @@
+# ISerializable
+
+**Header:** `ScriptBinder/ISerializable.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `virtual ~ISerializable() = default;`
+- `virtual nlohmann::json SerializeData() const = 0;`
+- `virtual void DeserializeData(const nlohmann::json& json) = 0;`
+- `virtual std::string GetModuleType() const = 0;`
+
+## Public Properties
+- (none)

--- a/API_DOCS/ImageComponent.md
+++ b/API_DOCS/ImageComponent.md
@@ -1,0 +1,23 @@
+# ImageComponent
+
+**Header:** `ScriptBinder/ImageComponent.h`
+
+**Inheritance:** `: public UIComponent, public RegistableEvent<ImageComponent>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `ImageComponent();`
+- `~ImageComponent() = default;`
+- `void Load(const std::shared_ptr<Texture>& ptr);`
+- `void DeserializeTexture(const std::shared_ptr<Texture>& ptr);`
+- `virtual void Awake() override;`
+- `virtual void Update(float tick) override;`
+- `virtual void OnDestroy() override;`
+- `void UpdateTexture();`
+- `void SetTexture(int index);`
+- `void ResetSize();`
+- `bool isThisTextureExist(std::string_view path) const;`
+
+## Public Properties
+- (none)

--- a/API_DOCS/InputAction.md
+++ b/API_DOCS/InputAction.md
@@ -1,0 +1,24 @@
+# InputAction
+
+**Header:** `ScriptBinder/InputAction.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `InputAction() = default;`
+- `void SetControllerButton(ControllerButton _btn);`
+- `std::function<void()> buttonAction;`
+- `std::function<void(std::any)> valueAction;`
+
+## Public Properties
+- `std::string actionName;`
+- `InputType inputType= InputType::KeyBoard;`
+- `ActionType actionType = ActionType::Button;`
+- `KeyState  keystate  = KeyState::Down;`
+- `InputValueType valueType = InputValueType::Vector2;`
+- `size_t playerIndex = 0;`
+- `InputValue value;`
+- `std::string objName;`
+- `std::string m_scriptName  = "None";`
+- `std::string funName = "None";`
+- `ControllerButton m_controllerButton = ControllerButton::None;`

--- a/API_DOCS/InputActionManager.md
+++ b/API_DOCS/InputActionManager.md
@@ -1,0 +1,20 @@
+# InputActionManager
+
+**Header:** `ScriptBinder/InputActionManager.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `~InputActionManager() = default;`
+- `void Update(float tick);`
+- `void AddActionMap();`
+- `ActionMap* AddActionMap(std::string name);`
+- `void DeleteActionMap(std::string name);`
+- `ActionMap* FindActionMap(std::string name);`
+- `void SaveManager();`
+- `void LoadManager();`
+- `nlohmann::json SerializeMap(ActionMap* _actionMap);`
+- `ActionMap* DeSerializeMap(std::string _filepath);`
+
+## Public Properties
+- `std::vector<ActionMap*> m_actionMaps;`

--- a/API_DOCS/InputManager.md
+++ b/API_DOCS/InputManager.md
@@ -1,0 +1,44 @@
+# InputManager
+
+**Header:** `ScriptBinder/InputManager.h`
+
+**Inheritance:** `: public DLLCore::Singleton<InputManager>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `bool Initialize(HWND _hwnd);`
+- `void Update(float deltaTime);`
+- `void KeyBoardUpdate();`
+- `bool IsAnyKeyPressed();`
+- `void MouseUpdate();`
+- `void SetMousePos(POINT pos);`
+- `float2 GetMousePos();`
+- `float2 GetMouseDelta() const;`
+- `bool IsWheelUp();`
+- `bool IsWheelDown();`
+- `bool IsMouseButtonDown(MouseKey button);`
+- `bool IsMouseButtonPressed(MouseKey button);`
+- `bool IsMouseButtonReleased(MouseKey button);`
+- `void HideCursor();`
+- `void ShowCursor();`
+- `void ResetMouseDelta();`
+- `int16 GetWheelDelta() const;`
+- `void PadUpdate();`
+- `void GamePadUpdate();`
+- `bool IsControllerConnected(DWORD Index);`
+- `bool IsControllerButtonDown(DWORD index, ControllerButton btn) const;`
+- `bool IsControllerButtonPressed(DWORD index, ControllerButton btn) const;`
+- `bool IsControllerButtonReleased(DWORD index, ControllerButton btn) const;`
+- `bool IsControllerTriggerL(DWORD index) const;`
+- `bool IsControllerTriggerR(DWORD index) const;`
+- `Mathf::Vector2 GetControllerThumbL(DWORD index) const;`
+- `Mathf::Vector2 GetControllerThumbR(DWORD index) const;`
+- `void SetControllerVibration(DWORD Index, float leftMotorSpeed, float rightMotorSpeed, float lowFre, float highFre, float time);`
+- `void SetControllerVibration(DWORD Index, float leftMotorSpeed, float rightMotorSpeed, float lowFre, float highFre);`
+- `void UpdateControllerVibration(float tick);`
+- `void SetControllerVibrationTime(DWORD Index, float time);`
+
+## Public Properties
+- `float							deadZone = 0.24f;`
+- `float							triggerdeadZone = 0.1f;`

--- a/API_DOCS/InputType.md
+++ b/API_DOCS/InputType.md
@@ -1,0 +1,11 @@
+# InputType
+
+**Header:** `ScriptBinder/KeyState.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/InputValueType.md
+++ b/API_DOCS/InputValueType.md
@@ -1,0 +1,11 @@
+# InputValueType
+
+**Header:** `ScriptBinder/InputAction.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/InvalidScriptComponent.md
+++ b/API_DOCS/InvalidScriptComponent.md
@@ -1,0 +1,13 @@
+# InvalidScriptComponent
+
+**Header:** `ScriptBinder/InvalidScriptComponent.h`
+
+**Inheritance:** `: public Component`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/InverterNode.md
+++ b/API_DOCS/InverterNode.md
@@ -1,0 +1,14 @@
+# InverterNode
+
+**Header:** `ScriptBinder/BTHeader.h`
+
+**Inheritance:** `: public DecoratorNode`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `InverterNode() = default;`
+- `~InverterNode() override = default;`
+
+## Public Properties
+- (none)

--- a/API_DOCS/KeyState.md
+++ b/API_DOCS/KeyState.md
@@ -1,0 +1,11 @@
+# KeyState
+
+**Header:** `ScriptBinder/KeyState.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/KeyboardState.md
+++ b/API_DOCS/KeyboardState.md
@@ -1,0 +1,11 @@
+# KeyboardState
+
+**Header:** `ScriptBinder/KeyState.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `void Update();`
+
+## Public Properties
+- (none)

--- a/API_DOCS/LightComponent.md
+++ b/API_DOCS/LightComponent.md
@@ -1,0 +1,13 @@
+# LightComponent
+
+**Header:** `ScriptBinder/LightComponent.h`
+
+**Inheritance:** `: public Component, public RegistableEvent<LightComponent>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/LinkData.md
+++ b/API_DOCS/LinkData.md
@@ -1,0 +1,12 @@
+# LinkData
+
+**Header:** `ScriptBinder/LinkData.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `LinkData() = default;`
+- `~LinkData() = default;`
+
+## Public Properties
+- (none)

--- a/API_DOCS/MeshColliderComponent.md
+++ b/API_DOCS/MeshColliderComponent.md
@@ -1,0 +1,13 @@
+# MeshColliderComponent
+
+**Header:** `ScriptBinder/MeshCollider.h`
+
+**Inheritance:** `: public Component, public ICollider, public RegistableEvent<MeshColliderComponent>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- `ConvexMeshColliderInfo m_Info;`

--- a/API_DOCS/MeshRenderer.md
+++ b/API_DOCS/MeshRenderer.md
@@ -1,0 +1,19 @@
+# MeshRenderer
+
+**Header:** `ScriptBinder/MeshRenderer.h`
+
+**Inheritance:** `: public Component, public RegistableEvent<MeshRenderer>, public std::enable_shared_from_this<MeshRenderer>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `MeshRenderer();`
+- `virtual ~MeshRenderer() override;`
+- `virtual void Awake() override;`
+- `virtual void OnDestroy() override;`
+- `BoundingBox GetBoundingBox() const;`
+
+## Public Properties
+- `LightMapping m_LightMapping;`
+- `bool m_shadowRecive = true;`
+- `bool m_shadowCast = true;`

--- a/API_DOCS/Mode.md
+++ b/API_DOCS/Mode.md
@@ -1,0 +1,11 @@
+# Mode
+
+**Header:** `ScriptBinder/TerrainBuffers.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/ModuleBehavior.md
+++ b/API_DOCS/ModuleBehavior.md
@@ -1,0 +1,13 @@
+# ModuleBehavior
+
+**Header:** `ScriptBinder/ModuleBehavior.h`
+
+**Inheritance:** `: public Component, public std::enable_shared_from_this<ModuleBehavior>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `ScriptFieldDefault();`
+
+## Public Properties
+- (none)

--- a/API_DOCS/MonoBehaviorEvent.md
+++ b/API_DOCS/MonoBehaviorEvent.md
@@ -1,0 +1,11 @@
+# MonoBehaviorEvent
+
+**Header:** `ScriptBinder/MonoBehaviorRecord.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/MonoManager.md
+++ b/API_DOCS/MonoManager.md
@@ -1,0 +1,32 @@
+# MonoManager
+
+**Header:** `ScriptBinder/MonoManager.h`
+
+**Inheritance:** `: public DLLCore::Singleton<MonoManager>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `void Shutdown();`
+- `std::optional<AssemblyPack> LoadAssembly(const std::string& name, const std::string& path);`
+- `void UnloadAllAssemblies();`
+- `bool ReloadAll(const std::vector<std::pair<std::string, std::string>>& assemblies);`
+- `MonoThread* AttachCurrentThread();`
+- `void        DetachCurrentThread();`
+- `void RegisterInternalCalls();`
+- `MonoClass* GetClass(const char* nameSpace, const char* klassName, MonoImage* image = nullptr) const;`
+- `MonoMethod* GetMethod(MonoClass* klass, const char* methodName, int paramCount) const;`
+- `MonoObject* InvokeStatic(MonoClass* klass, const char* methodName, void** args, int paramCount, MonoObject** outException = nullptr);`
+- `MonoObject* CreateInstance(MonoClass* klass);`
+- `MonoObject* Invoke(MonoObject* instance, const char* methodName, void** args, int paramCount, MonoObject** outException = nullptr);`
+- `MonoString* ToMonoString(const std::string& s) const;`
+- `std::string FromMonoString(MonoString* ms) const;`
+- `static std::string FormatException(MonoObject* exception);`
+- `void GCCollect();`
+- `void GCWaitForPendingFinalizers();`
+- `MonoImage* GetImage(const std::string& assemblyName) const;`
+- `void BindScriptEvents(CSharpScriptComponent* component);`
+- `void UnbindScriptEvents(CSharpScriptComponent* component);`
+
+## Public Properties
+- `bool enableDebug = false);`

--- a/API_DOCS/MouseState.md
+++ b/API_DOCS/MouseState.md
@@ -1,0 +1,12 @@
+# MouseState
+
+**Header:** `ScriptBinder/KeyState.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `MouseState() = default;`
+- `void Update();`
+
+## Public Properties
+- (none)

--- a/API_DOCS/NodeFactory.md
+++ b/API_DOCS/NodeFactory.md
@@ -1,0 +1,15 @@
+# NodeFactory
+
+**Header:** `ScriptBinder/NodeFactory.h`
+
+**Inheritance:** `: public DLLCore::Singleton<NodeFactory>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `using CreateNodeFunc = std::function<BTNode::NodePtr()>;`
+- `void Register(const std::string& typeName, CreateNodeFunc func);`
+- `BTNode::NodePtr Create(const std::string& typeName);`
+
+## Public Properties
+- `std::map<std::string, CreateNodeFunc> m_registry;`

--- a/API_DOCS/NodeStatus.md
+++ b/API_DOCS/NodeStatus.md
@@ -1,0 +1,11 @@
+# NodeStatus
+
+**Header:** `ScriptBinder/BTEnum.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/Object.md
+++ b/API_DOCS/Object.md
@@ -1,0 +1,18 @@
+# Object
+
+**Header:** `ScriptBinder/Object.h`
+
+**Inheritance:** `: public IObject, public Managed::HeapObject`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `Object() = default;`
+- `virtual ~Object() = default;`
+- `virtual void Destroy();`
+- `static void Destroy(Object* objPtr);`
+- `static void SetDontDestroyOnLoad(Object* objPtr);`
+- `static Object* Instantiate(const Object* original, std::string_view newName);`
+
+## Public Properties
+- (none)

--- a/API_DOCS/PadState.md
+++ b/API_DOCS/PadState.md
@@ -1,0 +1,12 @@
+# PadState
+
+**Header:** `ScriptBinder/KeyState.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `PadState() = default;`
+- `void Update();`
+
+## Public Properties
+- (none)

--- a/API_DOCS/ParallelNode.md
+++ b/API_DOCS/ParallelNode.md
@@ -1,0 +1,14 @@
+# ParallelNode
+
+**Header:** `ScriptBinder/BTHeader.h`
+
+**Inheritance:** `: public CompositeNode`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `ParallelNode() = default;`
+- `~ParallelNode() override = default;`
+
+## Public Properties
+- (none)

--- a/API_DOCS/ParallelPolicy.md
+++ b/API_DOCS/ParallelPolicy.md
@@ -1,0 +1,11 @@
+# ParallelPolicy
+
+**Header:** `ScriptBinder/BTEnum.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/PhysicsManager.md
+++ b/API_DOCS/PhysicsManager.md
@@ -1,0 +1,40 @@
+# PhysicsManager
+
+**Header:** `ScriptBinder/PhysicsManager.h`
+
+**Inheritance:** `: public DLLCore::Singleton<PhysicsManager>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `void Initialize();`
+- `void Update(float fixedDeltaTime);`
+- `void Shutdown();`
+- `void ChangeScene();`
+- `[[maybe_unused]] void OnLoadScene();`
+- `void OnUnloadScene();`
+- `void ProcessCallback();`
+- `void RayCast(RayEvent& rayEvent);`
+- `bool Raycast(RayEvent& rayEvent, RaycastHit& hit);`
+- `int Raycast(RayEvent& rayEvent, std::vector<RaycastHit>& hits);`
+- `int BoxSweep(const SweepInput& in, const DirectX::SimpleMath::Vector3& boxExtent, std::vector<HitResult>& out_hits);`
+- `int SphereSweep(const SweepInput& in, float radius, std::vector<HitResult>& out_hits);`
+- `int CapsuleSweep(const SweepInput& in, float radius, float halfHeight, std::vector<HitResult>& out_hits);`
+- `int BoxOverlap(const OverlapInput& in, const DirectX::SimpleMath::Vector3& boxExtent, std::vector<HitResult>& out_hits);`
+- `int SphereOverlap(const OverlapInput& in, float radius, std::vector<HitResult>& out_hits);`
+- `int CapsuleOverlap(const OverlapInput& in, float radius, float halfHeight, std::vector<HitResult>& out_hits);`
+- `void SaveCollisionMatrix();`
+- `void LoadCollisionMatrix();`
+- `void SetRigidBodyState(const RigidBodyState& state);`
+- `bool IsRigidBodyKinematic(unsigned int id) const;`
+- `bool IsRigidBodyTrigger(unsigned int id) const;`
+- `bool IsRigidBodyColliderEnabled(unsigned int id) const;`
+- `bool IsRigidBodyUseGravity(unsigned int id) const;`
+- `void ApplyForcedMoveToCCT(UINT controllerId, const DirectX::SimpleMath::Vector3& initialVelocity);`
+- `void StopForcedMoveOnCCT(UINT controllerId);`
+- `bool IsInForcedMove(UINT controllerId) const;`
+- `void SetControllerPosition(UINT id, const DirectX::SimpleMath::Vector3& pos);`
+
+## Public Properties
+- `friend class Scene;`
+- `using ColliderID = unsigned int;`

--- a/API_DOCS/PlayerInputComponent.md
+++ b/API_DOCS/PlayerInputComponent.md
@@ -1,0 +1,19 @@
+# PlayerInputComponent
+
+**Header:** `ScriptBinder/PlayerInput.h`
+
+**Inheritance:** `: public Component, public RegistableEvent<PlayerInputComponent>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `void Update(float tick) override;`
+- `void SetActionMap(std::string mapName);`
+- `void SetActionMap(ActionMap* _actionMap);`
+- `void SetControllerVibration(float tick, float leftMotorSpeed, float rightMotorSpeed, float lowFre, float highFre);`
+- `void SetControllerVibration(float tick, float power);`
+
+## Public Properties
+- `ActionMap* m_actionMap = nullptr;`
+- `std::string m_actionMapName = "None";`
+- `int controllerIndex = 0;`

--- a/API_DOCS/Prefab.md
+++ b/API_DOCS/Prefab.md
@@ -1,0 +1,18 @@
+# Prefab
+
+**Header:** `ScriptBinder/Prefab.h`
+
+**Inheritance:** `: public Object`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `Prefab() = default;`
+- `Prefab(std::string_view name, const GameObject* source);`
+- `~Prefab() override = default;`
+- `static Prefab* CreateFromGameObject(const GameObject* source, std::string_view name = "");`
+- `GameObject* Instantiate(std::string_view newName = "") const;`
+- `GameObject* Instantiate(Scene* targetScene, std::string_view newName = "") const;`
+
+## Public Properties
+- (none)

--- a/API_DOCS/PrefabEditor.md
+++ b/API_DOCS/PrefabEditor.md
@@ -1,0 +1,14 @@
+# PrefabEditor
+
+**Header:** `ScriptBinder/PrefabEditor.h`
+
+**Inheritance:** `: public Singleton<PrefabEditor>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `void Open(const std::string& path);`
+- `void Close(bool apply = true);`
+
+## Public Properties
+- (none)

--- a/API_DOCS/PrefabUtility.md
+++ b/API_DOCS/PrefabUtility.md
@@ -1,0 +1,24 @@
+# PrefabUtility
+
+**Header:** `ScriptBinder/PrefabUtility.h`
+
+**Inheritance:** `: public DLLCore::Singleton<PrefabUtility>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `Prefab* CreatePrefab(const GameObject* source, std::string_view name = "");`
+- `GameObject* InstantiatePrefab(const Prefab* prefab, std::string_view name = "");`
+- `GameObject* InstantiatePrefab(const Prefab* prefab, Scene* targetScene, std::string_view name = "");`
+- `void RegisterInstance(GameObject* instance, const Prefab* prefab);`
+- `void UpdateInstances(const Prefab* prefab);`
+- `bool SavePrefab(const Prefab* prefab, const std::string& path);`
+- `Prefab* LoadPrefabFullPath(const std::string& path);`
+- `Prefab* LoadPrefab(const std::string& path);`
+- `Prefab* LoadPrefabGuid(const FileGuid& guid);`
+
+## Public Properties
+- `Core::Delegate<void, GameObject&> prefabInstanceUpdated;`
+- `Core::Delegate<void, GameObject&> prefabInstanceApplied;`
+- `Core::Delegate<void, GameObject&> prefabInstanceReverted;`
+- `Core::Delegate<void, GameObject&> prefabInstanceUnpacked;`

--- a/API_DOCS/RagdollComponent.md
+++ b/API_DOCS/RagdollComponent.md
@@ -1,0 +1,13 @@
+# RagdollComponent
+
+**Header:** `ScriptBinder/RagdollComponent.h`
+
+**Inheritance:** `: public Component, public ICollider`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/RectTransformComponent.md
+++ b/API_DOCS/RectTransformComponent.md
@@ -1,0 +1,23 @@
+# RectTransformComponent
+
+**Header:** `ScriptBinder/RectTransformComponent.h`
+
+**Inheritance:** `: public Component`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `RectTransformComponent();`
+- `virtual ~RectTransformComponent() = default;`
+- `void UpdateLayout(const Mathf::Rect& parentRect);`
+- `void SetAnchorMin(const Mathf::Vector2& anchorMin);`
+- `void SetAnchorMax(const Mathf::Vector2& anchorMax);`
+- `Mathf::Vector2 GetAnchoredPosition() const;`
+- `void SetAnchoredPosition(const Mathf::Vector2& position);`
+- `void SetSizeDelta(const Mathf::Vector2& size);`
+- `void SetPivot(const Mathf::Vector2& pivot);`
+- `void SetAnchorPreset(AnchorPreset preset);`
+- `void SetParentKeepWorldPosition(GameObject* newParent);`
+
+## Public Properties
+- `const Mathf::Rect& newParentRect);`

--- a/API_DOCS/RegistableEvent.md
+++ b/API_DOCS/RegistableEvent.md
@@ -1,0 +1,13 @@
+# RegistableEvent
+
+**Header:** `ScriptBinder/IRegistableEvent.h`
+
+**Inheritance:** `: public IRegistableEvent`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `void RegisterOverriddenEvents(Scene* scene) final override;`
+
+## Public Properties
+- (none)

--- a/API_DOCS/RigidBodyComponent.md
+++ b/API_DOCS/RigidBodyComponent.md
@@ -1,0 +1,24 @@
+# RigidBodyComponent
+
+**Header:** `ScriptBinder/RigidBodyComponent.h`
+
+**Inheritance:** `: public Component, public RegistableEvent<RigidBodyComponent>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `void Awake() override;`
+- `void OnDestroy() override;`
+- `void SetBodyType(const EBodyType& bodyType);`
+- `void SetAngularDamping(float _AngularDamping = 0.05f);`
+- `void SetLinearDamping(float _LinearDamping);`
+- `void AddForce(const Mathf::Vector3& force, EForceMode forceMode = EForceMode::FORCE);`
+- `void SetMass(float _mass);`
+- `void SetKinematic(bool isKinematic);`
+- `void SetIsTrigger(bool isTrigger);`
+- `void SetColliderEnabled(bool enabled);`
+- `void UseGravity(bool useGravity);`
+- `void NotifyPhysicsStateChange(const Mathf::Vector3& position);`
+
+## Public Properties
+- (none)

--- a/API_DOCS/Rolloff.md
+++ b/API_DOCS/Rolloff.md
@@ -1,0 +1,11 @@
+# Rolloff
+
+**Header:** `ScriptBinder/SoundDefinition.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/Scene.md
+++ b/API_DOCS/Scene.md
@@ -1,0 +1,89 @@
+# Scene
+
+**Header:** `ScriptBinder/Scene.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `Scene();`
+- `~Scene();`
+- `std::shared_ptr<GameObject> AddGameObject(const std::shared_ptr<GameObject>& sceneObject);`
+- `std::shared_ptr<GameObject> CreateGameObject(std::string_view name, GameObjectType type = GameObjectType::Empty, GameObject::Index parentIndex = -1);`
+- `std::shared_ptr<GameObject> LoadGameObject(size_t instanceID, std::string_view name, GameObjectType type = GameObjectType::Empty, GameObject::Index parentIndex = -1);`
+- `std::shared_ptr<GameObject> GetGameObject(GameObject::Index index);`
+- `std::shared_ptr<GameObject> TryGetGameObject(GameObject::Index index);`
+- `void DetachGameObjectHierarchy(GameObject* root);`
+- `GameObject::Index AttachExistingGameObject(std::shared_ptr<GameObject> go, GameObject::Index parentIndex);`
+- `AttachExistingGameObjectHierarchy(const std::vector<std::shared_ptr<GameObject>>& roots);`
+- `std::shared_ptr<GameObject> GetGameObject(std::string_view name);`
+- `void AddSelectedSceneObject(GameObject* sceneObject);`
+- `void RemoveSelectedSceneObject(GameObject* sceneObject);`
+- `void ClearSelectedSceneObjects();`
+- `void AddRootGameObject(std::string_view name);`
+- `void DestroyGameObject(const std::shared_ptr<GameObject>& sceneObject);`
+- `void DestroyGameObject(GameObject::Index index);`
+- `void CullMeshData();`
+- `void InternalPauseUpdateForUI();`
+- `std::vector<std::shared_ptr<GameObject>> CreateGameObjects(size_t createSize, GameObject::Index parentIndex = -1);`
+- `void Awake();`
+- `void OnEnable();`
+- `void Start();`
+- `void FixedUpdate(float deltaSecond);`
+- `void OnTriggerEnter(const Collision& collider);`
+- `void OnTriggerStay(const Collision& collider);`
+- `void OnTriggerExit(const Collision& collider);`
+- `void OnCollisionEnter(const Collision& collider);`
+- `void OnCollisionStay(const Collision& collider);`
+- `void OnCollisionExit(const Collision& collider);`
+- `void Update(float deltaSecond);`
+- `void YieldNull();`
+- `void LateUpdate(float deltaSecond);`
+- `void OnDisable();`
+- `void OnDestroy();`
+- `void AllDestroyMark();`
+- `void ResetSelectedSceneObject();`
+- `void CollectLightComponent(LightComponent* ptr);`
+- `void UnCollectLightComponent(LightComponent* ptr);`
+- `uint32 UpdateLight(LightProperties& lightProperties) const;`
+- `std::pair<size_t, Light&> AddLight();`
+- `Light& GetLight(size_t index);`
+- `void RemoveLight(size_t index);`
+- `void DestroyLight();`
+- `void CollectMeshRenderer(MeshRenderer* ptr);`
+- `void UnCollectMeshRenderer(MeshRenderer* ptr);`
+- `void CollectSpriteRenderer(SpriteRenderer* ptr);`
+- `void UnCollectSpriteRenderer(SpriteRenderer* ptr);`
+- `void CollectTerrainComponent(TerrainComponent* ptr);`
+- `void UnCollectTerrainComponent(TerrainComponent* ptr);`
+- `void CollectFoliageComponent(FoliageComponent* ptr);`
+- `void UnCollectFoliageComponent(FoliageComponent* ptr);`
+- `void CollectDecalComponent(DecalComponent* ptr);`
+- `void UnCollectDecalComponent(DecalComponent* ptr);`
+- `void CollectRigidBodyComponent(RigidBodyComponent* ptr);`
+- `void UnCollectRigidBodyComponent(RigidBodyComponent* ptr);`
+- `void CollectColliderComponent(BoxColliderComponent* ptr);`
+- `void CollectColliderComponent(SphereColliderComponent* ptr);`
+- `void CollectColliderComponent(CapsuleColliderComponent* ptr);`
+- `void CollectColliderComponent(MeshColliderComponent* ptr);`
+- `void CollectColliderComponent(CharacterControllerComponent* ptr);`
+- `void CollectColliderComponent(TerrainColliderComponent* ptr);`
+- `void UnCollectColliderComponent(BoxColliderComponent* ptr);`
+- `void UnCollectColliderComponent(SphereColliderComponent* ptr);`
+- `void UnCollectColliderComponent(CapsuleColliderComponent* ptr);`
+- `void UnCollectColliderComponent(MeshColliderComponent* ptr);`
+- `void UnCollectColliderComponent(CharacterControllerComponent* ptr);`
+- `void UnCollectColliderComponent(TerrainColliderComponent* ptr);`
+- `void AddCanvas(const std::shared_ptr<GameObject>& canvas);`
+- `void RemoveCanvas(const std::shared_ptr<GameObject>& canvas);`
+- `std::shared_ptr<GameObject> FindCanvasName(std::string_view name);`
+- `std::shared_ptr<GameObject> FindCanvasIndex(size_t index);`
+- `void AllUpdateWorldMatrix();`
+- `void AllUIUpdateWorldMatrix();`
+
+## Public Properties
+- `std::vector<std::shared_ptr<GameObject>> m_SceneObjects;`
+- `std::future<void> m_AIFuture;`
+- `HashingString m_sceneName;`
+- `GameObject*					m_selectedSceneObject = nullptr;`
+- `std::vector<GameObject*>	m_selectedSceneObjects;`
+- `std::vector<std::shared_ptr<MeshRenderer>> m_visibleMeshesScratch;`

--- a/API_DOCS/SceneManager.md
+++ b/API_DOCS/SceneManager.md
@@ -1,0 +1,45 @@
+# SceneManager
+
+**Header:** `ScriptBinder/SceneManager.h`
+
+**Inheritance:** `: public DLLCore::Singleton<SceneManager>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `void ManagerInitialize();`
+- `void Editor();`
+- `void Initialization();`
+- `void Physics(float deltaSecond);`
+- `void InputEvents(float deltaSecond);`
+- `void GameLogic(float deltaSecond = 0);`
+- `void SceneRendering(float deltaSecond);`
+- `void OnDrawGizmos();`
+- `void GUIRendering();`
+- `void EndOfFrame();`
+- `void Pausing();`
+- `void DisableOrEnable();`
+- `void Decommissioning();`
+- `void SetDecommissioning();`
+- `Scene* CreateScene(std::string_view name = "SampleScene");`
+- `Scene* SaveScene(std::string_view name = "SampleScene");`
+- `Scene* LoadSceneImmediate(std::string_view name = "SampleScene");`
+- `Scene* LoadScene(std::string_view name = "SampleScene");`
+- `void SaveSceneAsync(std::string_view name = "SampleScene");`
+- `std::future<Scene*> LoadSceneAsync(std::string_view name = "SampleScene");`
+- `void LoadSceneAsyncAndWaitCallback(std::string_view name = "SampleScene");`
+- `void ActivateScene(Scene* sceneToActivate, bool isOldSceneDelete = true);`
+- `void BeforeAwakeSceneLoad();`
+- `bool IsSceneLoading() const;`
+- `void WaitForSceneLoad();`
+- `void AddDontDestroyOnLoad(std::shared_ptr<Object> objPtr);`
+- `void RemoveDontDestroyOnLoad(std::shared_ptr<Object> objPtr);`
+- `void RebindEventDontDestroyOnLoadObjects(Scene* scene);`
+- `void SetGameStart(bool isStart);`
+- `void SetGamePaused(bool isPaused);`
+- `void ToggleGamePaused();`
+- `std::vector<MeshRenderer*> GetAllMeshRenderers() const;`
+- `void VolumeProfileApply();`
+
+## Public Properties
+- `std::future<Scene*>                 m_loadingSceneFuture;`

--- a/API_DOCS/SelectorNode.md
+++ b/API_DOCS/SelectorNode.md
@@ -1,0 +1,14 @@
+# SelectorNode
+
+**Header:** `ScriptBinder/BTHeader.h`
+
+**Inheritance:** `: public CompositeNode`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `SelectorNode() = default;`
+- `~SelectorNode() override = default;`
+
+## Public Properties
+- (none)

--- a/API_DOCS/SequenceNode.md
+++ b/API_DOCS/SequenceNode.md
@@ -1,0 +1,14 @@
+# SequenceNode
+
+**Header:** `ScriptBinder/BTHeader.h`
+
+**Inheritance:** `: public CompositeNode`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `SequenceNode() = default;`
+- `~SequenceNode() override = default;`
+
+## Public Properties
+- (none)

--- a/API_DOCS/SoundComponent.md
+++ b/API_DOCS/SoundComponent.md
@@ -1,0 +1,37 @@
+# SoundComponent
+
+**Header:** `ScriptBinder/SoundComponent.h`
+
+**Inheritance:** `: public Component, public RegistableEvent<SoundComponent>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `void Start() override;`
+- `void Update(float tick) override;`
+- `void LateUpdate(float tick) override;`
+- `void OnDestroy() override;`
+- `void Play();`
+- `void Stop();`
+- `void Pause(bool pause);`
+- `bool IsPlaying();`
+- `void PlayOneShot();`
+- `void EditorSet();`
+
+## Public Properties
+- `std::string clipKey;`
+- `ChannelType bus = ChannelType::SFX;`
+- `float volume = 1.f;`
+- `float pitch = 1.f;`
+- `int priority = 128;`
+- `float spatialBlend = 1.0f;`
+- `float minDistance = 1.0f;`
+- `float maxDistance = 50.0f;`
+- `float  reverbLevel = 0.0f;`
+- `int    reverbIndex = 0;`
+- `Rolloff rolloff = Rolloff::Inverse;`
+- `std::vector<CurvePoint> localRolloffCurve;`
+- `bool loop = false;`
+- `bool playOnStart = false;`
+- `bool spatial = false;`
+- `bool useReverbSend = false;`

--- a/API_DOCS/SoundManager.md
+++ b/API_DOCS/SoundManager.md
@@ -1,0 +1,35 @@
+# SoundManager
+
+**Header:** `ScriptBinder/SoundManager.h`
+
+**Inheritance:** `: public DLLCore::Singleton<SoundManager>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `bool initialize(int maxChannels);`
+- `void update();`
+- `void shutdown();`
+- `void Initialize();`
+- `void SoundLoaderThread();`
+- `void LoadSounds();`
+- `void setMasterVolume(float volume);`
+- `void setBusVolume(ChannelType bus, float linear);`
+- `void setBusVolumeDb(ChannelType bus, float db);`
+- `void setBusVolumePercent(ChannelType bus, int percent);`
+- `void unloadSound(const std::string& name);`
+- `std::vector<std::string> getAllClipKeys() const;`
+- `void setGroupMaxVoices(ChannelType bus, int maxVoices);`
+- `void setGroupStealPolicy(ChannelType bus, StealPolicy p);`
+- `void setGroupPreemptSameClip(ChannelType bus, bool on);`
+- `void configureVoicePool(const std::string& clipKey, ChannelType bus, int capacity);`
+- `void clearVoicePool(const std::string& clipKey, ChannelType bus);`
+- `void stopByOwnerTag(void* ownerTag);`
+- `void stopByOwnerTag(void* ownerTag, ChannelType bus);`
+- `bool getListenerPosition(FMOD_VECTOR& out) const;`
+
+## Public Properties
+- `const FMOD_VECTOR& up);`
+- `bool is3D = false, bool loop = false);`
+- `void* ownerTag = nullptr);`
+- `void* ownerTag = nullptr);`

--- a/API_DOCS/SphereColliderComponent.md
+++ b/API_DOCS/SphereColliderComponent.md
@@ -1,0 +1,17 @@
+# SphereColliderComponent
+
+**Header:** `ScriptBinder/SphereColliderComponent.h`
+
+**Inheritance:** `: public Component, public ICollider, public RegistableEvent<SphereColliderComponent>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- `float radius = 1.0f;`
+- `float staticFriction = 0.5f;`
+- `float dynamicFriction = 0.4f;`
+- `float restitution = 0.3f;`
+- `float density = 10.0f;`

--- a/API_DOCS/SpriteRenderer.md
+++ b/API_DOCS/SpriteRenderer.md
@@ -1,0 +1,15 @@
+# SpriteRenderer
+
+**Header:** `ScriptBinder/SpriteRenderer.h`
+
+**Inheritance:** `: public Component, public RegistableEvent<SpriteRenderer>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `virtual void Awake() override;`
+- `virtual void OnDestroy() override;`
+- `void SetSprite(const std::shared_ptr<Texture>& ptr);`
+
+## Public Properties
+- (none)

--- a/API_DOCS/SpriteSheetComponent.md
+++ b/API_DOCS/SpriteSheetComponent.md
@@ -1,0 +1,16 @@
+# SpriteSheetComponent
+
+**Header:** `ScriptBinder/SpriteSheetComponent.h`
+
+**Inheritance:** `: public UIComponent, public RegistableEvent<SpriteSheetComponent>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `void LoadSpriteSheet(const file::path& path);`
+- `virtual void Awake() override;`
+- `virtual void Update(float tick) override;`
+- `virtual void OnDestroy() override;`
+
+## Public Properties
+- (none)

--- a/API_DOCS/StateMachineComponent.md
+++ b/API_DOCS/StateMachineComponent.md
@@ -1,0 +1,20 @@
+# StateMachineComponent
+
+**Header:** `ScriptBinder/StateMachineComponent.h`
+
+**Inheritance:** `:public Component, public IAIComponent`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `using ConditionFunc = std::function<bool(const BlackBoard&)>;`
+- `virtual ~StateMachineComponent() = default;`
+- `void Initialize() override;`
+- `FSM::FSMState* AddState(const std::string& name);`
+- `void RemoveState(FSM::FSMState* state);`
+- `FSM::Transition* AddTransition(FSM::FSMState* from, FSM::FSMState* to, ConditionFunc condition);`
+- `void RemoveTransition(FSM::Transition* transition);`
+- `FSM::FSMState* FindStateByName(const std::string& name) const;`
+
+## Public Properties
+- `std::string name;`

--- a/API_DOCS/StaticGameObjectType.md
+++ b/API_DOCS/StaticGameObjectType.md
@@ -1,0 +1,13 @@
+# StaticGameObjectType
+
+**Header:** `ScriptBinder/GameObjectType.h`
+
+**Inheritance:** `: flag`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/StealPolicy.md
+++ b/API_DOCS/StealPolicy.md
@@ -1,0 +1,11 @@
+# StealPolicy
+
+**Header:** `ScriptBinder/SoundDefinition.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/TagManager.md
+++ b/API_DOCS/TagManager.md
@@ -1,0 +1,26 @@
+# TagManager
+
+**Header:** `ScriptBinder/TagManager.h`
+
+**Inheritance:** `: public DLLCore::Singleton<TagManager>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `void Initialize();`
+- `void Finalize();`
+- `void Load();`
+- `void Save();`
+- `void AddTag(std::string_view tag);`
+- `void RemoveTag(std::string_view tag);`
+- `bool HasTag(std::string_view tag) const;`
+- `void AddLayer(std::string_view layer);`
+- `void RemoveLayer(std::string_view layer);`
+- `bool HasLayer(std::string_view layer) const;`
+- `void AddTagToObject(std::string_view tag, GameObject* object);`
+- `void RemoveTagFromObject(std::string_view tag, GameObject* object);`
+- `void AddObjectToLayer(std::string_view layer, GameObject* object);`
+- `void RemoveObjectFromLayer(std::string_view layer, GameObject* object);`
+
+## Public Properties
+- (none)

--- a/API_DOCS/TerrainColliderComponent.md
+++ b/API_DOCS/TerrainColliderComponent.md
@@ -1,0 +1,13 @@
+# TerrainColliderComponent
+
+**Header:** `ScriptBinder/TerrainCollider.h`
+
+**Inheritance:** `: public Component, public ICollider, public RegistableEvent<TerrainColliderComponent>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/TerrainComponent.md
+++ b/API_DOCS/TerrainComponent.md
@@ -1,0 +1,32 @@
+# TerrainComponent
+
+**Header:** `ScriptBinder/Terrain.h`
+
+**Inheritance:** `: public Component, public RegistableEvent<TerrainComponent>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `TerrainComponent();`
+- `virtual ~TerrainComponent() = default;`
+- `void Initialize();`
+- `void Resize(int newWidth, int newHeight);`
+- `virtual void Awake() override;`
+- `virtual void OnDestroy() override;`
+- `void Save(const std::wstring& assetRoot, const std::wstring& name);`
+- `bool Load(const std::wstring& filePath);`
+- `void BuildOutTrrain(const std::wstring& buildPath, const std::wstring& terrainName);`
+- `bool LoadRunTimeTerrain(const std::wstring& filePath);`
+- `void ApplyBrush(const TerrainBrush& brush);`
+- `void RecalculateNormalsPatch(int minX, int minY, int maxX, int maxY);`
+- `void PaintLayer(uint32_t layerId, int x, int y, float strength);`
+- `void UpdateLayerDesc();`
+- `void AddLayer(const std::wstring& path, const std::wstring& diffuseFile, float tilling);`
+- `void RemoveLayer(uint32_t layerID);`
+- `void ClearLayers();`
+- `void RefreshTexture();`
+- `bool LoadBrushMaskTexture(const std::wstring& path, std::vector<uint8_t>& outMask, int& dataWidth, int& dataHeight);`
+- `void SetBrushMaskTexture(TerrainBrush* brush, const std::wstring& path);`
+
+## Public Properties
+- (none)

--- a/API_DOCS/TextAlignment.md
+++ b/API_DOCS/TextAlignment.md
@@ -1,0 +1,13 @@
+# TextAlignment
+
+**Header:** `ScriptBinder/Navigation.h`
+
+**Inheritance:** `: std::uint8_t`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/TextComponent.md
+++ b/API_DOCS/TextComponent.md
@@ -1,0 +1,18 @@
+# TextComponent
+
+**Header:** `ScriptBinder/TextComponent.h`
+
+**Inheritance:** `: public UIComponent, public RegistableEvent<TextComponent>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `TextComponent();`
+- `~TextComponent() = default;`
+- `virtual void Awake() override;`
+- `virtual void Update(float tick) override;`
+- `virtual void OnDestroy() override;`
+- `void SetFont(const file::path& path);`
+
+## Public Properties
+- (none)

--- a/API_DOCS/TransCondition.md
+++ b/API_DOCS/TransCondition.md
@@ -1,0 +1,19 @@
+# TransCondition
+
+**Header:** `ScriptBinder/TransCondition.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `TransCondition() = default;`
+- `bool CheckTrans();`
+- `void SetValue(std::string valueName);`
+- `void SetCondition(std::string _parameterName);`
+- `nlohmann::json Serialize();`
+- `TransCondition Deserialize();`
+
+## Public Properties
+- `std::string valueName = "None";`
+- `ConditionParameter* valueParameter;`
+- `ConditionParameter CompareParameter;`
+- `ConditionType cType = ConditionType::Equal;`

--- a/API_DOCS/Transition.md
+++ b/API_DOCS/Transition.md
@@ -1,0 +1,11 @@
+# Transition
+
+**Header:** `ScriptBinder/Transition.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/Type.md
+++ b/API_DOCS/Type.md
@@ -1,0 +1,11 @@
+# Type
+
+**Header:** `ScriptBinder/GameObject.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/UIButton.md
+++ b/API_DOCS/UIButton.md
@@ -1,0 +1,16 @@
+# UIButton
+
+**Header:** `ScriptBinder/UIButton.h`
+
+**Inheritance:** `: public UIComponent, public RegistableEvent<UIButton>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `void Update(float deltaSecond) override;`
+- `void UpdateCollider();`
+- `bool CheckClick(Mathf::Vector2 _mousePos);`
+- `void Click();`
+
+## Public Properties
+- `bool isClick = false;`

--- a/API_DOCS/UIColliderType.md
+++ b/API_DOCS/UIColliderType.md
@@ -1,0 +1,13 @@
+# UIColliderType
+
+**Header:** `ScriptBinder/UIButton.h`
+
+**Inheritance:** `: uint8_t`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/UIComponent.md
+++ b/API_DOCS/UIComponent.md
@@ -1,0 +1,39 @@
+# UIComponent
+
+**Header:** `ScriptBinder/UIComponent.h`
+
+**Inheritance:** `: public Component`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `UIComponent();`
+- `virtual ~UIComponent() = default;`
+- `void SetCanvas(Canvas* canvas);`
+- `void SetNavi(Direction dir, const std::shared_ptr<GameObject>& otherUI);`
+- `void DeserializeNavi();`
+- `GameObject* GetNextNavi(Direction dir);`
+- `bool IsNavigationThis();`
+- `void DeserializeShader();`
+- `void SetCustomPixelShader(std::string_view shaderPath);`
+- `std::optional<float> GetFloat(std::string_view name) const;`
+- `void SetFloat(std::string_view name, float value);`
+- `std::optional<float2> GetFloat2(std::string_view name) const;`
+- `void SetFloat2(std::string_view name, const float2& value);`
+- `std::optional<float3> GetFloat3(std::string_view name) const;`
+- `void SetFloat3(std::string_view name, const float3& value);`
+- `std::optional<float4> GetFloat4(std::string_view name) const;`
+- `void SetFloat4(std::string_view name, const float4& value);`
+- `std::optional<int> GetInt(std::string_view name) const;`
+- `void SetInt(std::string_view name, int value);`
+- `std::optional<int2> GetInt2(std::string_view name) const;`
+- `void SetInt2(std::string_view name, const int2& value);`
+- `std::optional<int3> GetInt3(std::string_view name) const;`
+- `void SetInt3(std::string_view name, const int3& value);`
+- `std::optional<int4> GetInt4(std::string_view name) const;`
+- `void SetInt4(std::string_view name, const int4& value);`
+
+## Public Properties
+- `UItype type = UItype::None;`
+- `bool isDeserialized = false;`
+- `bool isNavLocked = false;`

--- a/API_DOCS/UIEffects.md
+++ b/API_DOCS/UIEffects.md
@@ -1,0 +1,11 @@
+# UIEffects
+
+**Header:** `ScriptBinder/Navigation.h`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/UIManager.md
+++ b/API_DOCS/UIManager.md
@@ -1,0 +1,35 @@
+# UIManager
+
+**Header:** `ScriptBinder/UIManager.h`
+
+**Inheritance:** `: public DLLCore::Singleton<UIManager>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `std::shared_ptr<GameObject> MakeCanvas(std::string_view name = "Canvas");`
+- `void AddCanvas(std::shared_ptr<GameObject> canvas);`
+- `void DeleteCanvas(const std::shared_ptr<GameObject>& canvas);`
+- `void CheckInput();`
+- `GameObject* FindCanvasName(const std::shared_ptr<GameObject>& obj, std::string_view name);`
+- `GameObject* FindCanvasIndex(const std::shared_ptr<GameObject>& obj, int index);`
+- `GameObject* FindCanvasName(std::string_view name);`
+- `GameObject* FindCanvasIndex(int index);`
+- `void Update();`
+- `void SortCanvas();`
+- `void RegisterImageComponent(ImageComponent* image);`
+- `void RegisterTextComponent(TextComponent* text);`
+- `void RegisterSpriteSheetComponent(SpriteSheetComponent* spriteSheet);`
+- `void UnregisterImageComponent(ImageComponent* image);`
+- `void UnregisterTextComponent(TextComponent* text);`
+- `void UnregisterSpriteSheetComponent(SpriteSheetComponent* spriteSheet);`
+
+## Public Properties
+- `friend class DLLCore::Singleton<UIManager>;`
+- `Core::Delegate<void, Mathf::Vector2> m_clickEvent;`
+- `std::vector<ImageComponent*>			Images;`
+- `std::vector<TextComponent*>			Texts;`
+- `std::vector<SpriteSheetComponent*>    SpriteSheets;`
+- `std::weak_ptr<GameObject> CurCanvas;`
+- `std::weak_ptr<GameObject> SelectUI;`
+- `bool needSort = false;`

--- a/API_DOCS/UItype.md
+++ b/API_DOCS/UItype.md
@@ -1,0 +1,13 @@
+# UItype
+
+**Header:** `ScriptBinder/UIComponent.h`
+
+**Inheritance:** `: uint16_t`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/ValueType.md
+++ b/API_DOCS/ValueType.md
@@ -1,0 +1,13 @@
+# ValueType
+
+**Header:** `ScriptBinder/ConditionParameter.h`
+
+**Inheritance:** `: std::uint16_t`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- (none)
+
+## Public Properties
+- (none)

--- a/API_DOCS/VolumeComponent.md
+++ b/API_DOCS/VolumeComponent.md
@@ -1,0 +1,16 @@
+# VolumeComponent
+
+**Header:** `ScriptBinder/VolumeComponent.h`
+
+**Inheritance:** `: public Component, public RegistableEvent<VolumeComponent>`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `void Awake() override;`
+- `void OnDestroy() override;`
+- `void LoadProfile(FileGuid profileGuid);`
+- `void UpdateProfileEditMode();`
+
+## Public Properties
+- (none)

--- a/API_DOCS/WeightedSelectorNode.md
+++ b/API_DOCS/WeightedSelectorNode.md
@@ -1,0 +1,14 @@
+# WeightedSelectorNode
+
+**Header:** `ScriptBinder/BTHeader.h`
+
+**Inheritance:** `: public CompositeNode`
+
+> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
+
+## Public Methods
+- `WeightedSelectorNode() = default;`
+- `~WeightedSelectorNode() override = default;`
+
+## Public Properties
+- (none)

--- a/docs/generate_scriptbinder_docs.py
+++ b/docs/generate_scriptbinder_docs.py
@@ -1,0 +1,135 @@
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_BINDER = REPO_ROOT / "ScriptBinder"
+OUTPUT_DIR = REPO_ROOT / "API_DOCS"
+
+CLASS_PATTERN = re.compile(r"class\s+(\w+)\s*([^\{;]*?)\{")
+ACCESS_SPECIFIERS = {"public:", "protected:", "private:"}
+COMMENT_PATTERN = re.compile(r"//.*?$|/\*.*?\*/", re.S | re.M)
+
+def read_file(path: Path) -> str:
+    with path.open(encoding="utf-8", errors="ignore") as f:
+        return f.read()
+
+def find_matching_brace(text: str, start_index: int) -> int:
+    depth = 1
+    i = start_index
+    while i < len(text) and depth > 0:
+        char = text[i]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+        i += 1
+    return i
+
+def clean_member_line(line: str) -> str:
+    line = line.strip()
+    if "//" in line:
+        line = line.split("//", 1)[0].strip()
+    return line
+
+def extract_class_blocks(header_content: str):
+    header_content = re.sub(COMMENT_PATTERN, "", header_content)
+    classes = []
+    for match in CLASS_PATTERN.finditer(header_content):
+        name = match.group(1)
+        inheritance = match.group(2).strip()
+        start = match.end()
+        end = find_matching_brace(header_content, start)
+        body = header_content[start:end-1]
+        classes.append((name, inheritance, body))
+    return classes
+
+def parse_public_interface(body: str):
+    current_access = "private"
+    methods = []
+    properties = []
+    brace_depth = 0
+
+    for raw_line in body.splitlines():
+        line = clean_member_line(raw_line)
+        if not line:
+            continue
+        lower = line.lower()
+        if lower in ACCESS_SPECIFIERS:
+            current_access = lower[:-1]
+            continue
+        if current_access != "public":
+            continue
+        # Skip forward declarations or nested classes
+        if line.startswith("class "):
+            continue
+        brace_delta = line.count("{") - line.count("}")
+        if brace_depth > 0:
+            brace_depth += brace_delta
+            continue
+        if "{" in line:
+            brace_depth += brace_delta
+            continue
+        if line.endswith("};") or line == "};":
+            continue
+        if "return " in line:
+            continue
+        if "(" in line and ")" in line and line.endswith(";"):
+            methods.append(line)
+        elif line.endswith(";"):
+            properties.append(line)
+    return methods, properties
+
+def write_markdown(class_name: str, inheritance: str, methods, properties, source: Path):
+    OUTPUT_DIR.mkdir(exist_ok=True)
+    doc_path = OUTPUT_DIR / f"{class_name}.md"
+    header_rel = source.relative_to(REPO_ROOT)
+    lines = [
+        f"# {class_name}",
+        "",
+        f"**Header:** `{header_rel}`",
+    ]
+    if inheritance:
+        formatted_inherit = inheritance.replace(" :", ":").strip()
+        lines.extend(["", f"**Inheritance:** `{formatted_inherit}`"])
+    lines.extend([
+        "",
+        "> 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.",
+        "",
+    ])
+    lines.append("## Public Methods")
+    if methods:
+        for method in methods:
+            lines.append(f"- `{method}`")
+    else:
+        lines.append("- (none)")
+    lines.extend(["", "## Public Properties"])
+    if properties:
+        for prop in properties:
+            lines.append(f"- `{prop}`")
+    else:
+        lines.append("- (none)")
+    doc_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return doc_path
+
+def generate_docs():
+    headers = sorted(SCRIPT_BINDER.rglob("*.h"))
+    if not headers:
+        print("No header files found under ScriptBinder.")
+        return
+    generated_files = []
+    for header in headers:
+        content = read_file(header)
+        class_blocks = extract_class_blocks(content)
+        for class_name, inheritance, body in class_blocks:
+            methods, properties = parse_public_interface(body)
+            doc_path = write_markdown(class_name, inheritance, methods, properties, header)
+            generated_files.append(doc_path)
+    print(f"Generated {len(generated_files)} documentation files in {OUTPUT_DIR}.")
+
+if __name__ == "__main__":
+    try:
+        generate_docs()
+    except Exception as exc:
+        print(f"Error while generating docs: {exc}")
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- add a Python helper that walks ScriptBinder headers and emits Unity-style Markdown docs
- generate Markdown API_DOCS for ScriptBinder classes using the helper script

## Testing
- python docs/generate_scriptbinder_docs.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69286f0d0fdc832d81d409a654d4e8d5)