### PR TITLE
Rewrite API sections with role tables only

### DIFF
--- a/API_DOCS/AIManager.md
+++ b/API_DOCS/AIManager.md
@@ -7,14 +7,19 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `BlackBoard* CreateBlackBoard(const std::string& aiName);`
-- `void RemoveBlackBoard(const std::string& aiName);`
-- `void RegisterAIComponent(GameObject* gameObject, IAIComponent* aiComponent);`
-- `void UnRegisterAIComponent(GameObject* gameObject, IAIComponent* aiComponent);`
-- `void InternalAIUpdate(float deltaSeconds);`
-- `BT::BTNode::NodePtr CreateNode(std::string_view nodeName);`
-- `void ClearTreeInAIComponent();`
-- `void InitalizeBehaviorTreeSystem();`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `CreateBlackBoard` | black board을(를) 생성합니다. |
+| `RemoveBlackBoard` | black board을(를) 제거합니다. |
+| `RegisterAIComponent` | register aicomponent 동작을 수행합니다. |
+| `UnRegisterAIComponent` | un register aicomponent 동작을 수행합니다. |
+| `InternalAIUpdate` | internal aiupdate 동작을 수행합니다. |
+| `CreateNode` | node을(를) 생성합니다. |
+| `ClearTreeInAIComponent` | tree in aicomponent을(를) 비웁니다. |
+| `InitalizeBehaviorTreeSystem` | initalize behavior tree system 동작을 수행합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/AIType.md
+++ b/API_DOCS/AIType.md
@@ -5,7 +5,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/ActionMap.md
+++ b/API_DOCS/ActionMap.md
@@ -5,19 +5,23 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `ActionMap() = default;`
-- `~ActionMap();`
-- `InputAction* AddAction();`
-- `void AddButtonAction(std::string name, size_t _playerindex, InputType _inputType, size_t _key, KeyState _state, std::function<void()> _action);`
-- `void AddButtonAction(std::string name, size_t _playerindex, InputType _inputType, size_t _key, KeyState _state, void (*_action)());`
-- `void AddValueAction(std::string name, size_t _playerindex, InputValueType _inputValueType, InputType _inputType, std::vector<size_t> _keys, std::function<void(Mathf::Vector2)> _action);`
-- `void AddValueAction(std::string name, size_t _playerindex, InputValueType _inputValueType, InputType _inputType, std::vector<size_t> _keys, std::function<void(float)> _action);`
-- `void CheckAction();`
-- `void CheckAction(int playerIndex,void* instance, const Meta::Type* type);`
-- `void InvokeAction(void* instance, const Meta::Type* type, const std::string& methodName, const std::vector<std::any>& args);`
-- `void DeleteAction(const std::string& name);`
-- `InputAction* FindAction(const std::string& name);`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `ActionMap` | action map 동작을 수행합니다. |
+| `~ActionMap` | action map 동작을 수행합니다. |
+| `AddAction` | action을(를) 추가합니다. |
+| `AddButtonAction` | button action을(를) 추가합니다. |
+| `AddValueAction` | value action을(를) 추가합니다. |
+| `CheckAction` | check action 동작을 수행합니다. |
+| `InvokeAction` | invoke action 동작을 수행합니다. |
+| `DeleteAction` | delete action 동작을 수행합니다. |
+| `FindAction` | action을(를) 탐색합니다. |
 ## Public Properties
-- `std::string m_name;`
-- `std::vector<InputAction*> m_actions;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `m_name` | m name 상태를 보관합니다. |
+| `m_actions` | m actions 상태를 보관합니다. |

--- a/API_DOCS/ActionNode.md
+++ b/API_DOCS/ActionNode.md
@@ -7,10 +7,15 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `using ActionFunc = std::function<NodeStatus(float, BlackBoard&)>;`
-- `ActionNode() = default;`
-- `~ActionNode() override = default;`
-- `NodeStatus Tick(float deltatime, BlackBoard& blackBoard) override abstract;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `ActionFunc` | action func 동작을 수행합니다. |
+| `ActionNode` | action node 동작을 수행합니다. |
+| `~ActionNode` | action node 동작을 수행합니다. |
+| `Tick` | tick 동작을 수행합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/ActionType.md
+++ b/API_DOCS/ActionType.md
@@ -5,7 +5,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/AnchorPreset.md
+++ b/API_DOCS/AnchorPreset.md
@@ -5,7 +5,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/AniBehavior.md
+++ b/API_DOCS/AniBehavior.md
@@ -5,8 +5,13 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `AniBehavior() = default;`
-- `virtual ~AniBehavior() = default;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `AniBehavior` | ani behavior 동작을 수행합니다. |
+| `~AniBehavior` | ani behavior 동작을 수행합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/AniTransition.md
+++ b/API_DOCS/AniTransition.md
@@ -5,25 +5,29 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `AniTransition() = default;`
-- `AniTransition(AnimationState* _curState, AnimationState* _nextState);`
-- `~AniTransition();`
-- `void DeleteCondition(int _index);`
-- `void SetCurState(std::string _curStateName);`
-- `void SetCurState(AnimationState* _curState);`
-- `void SetNextState(std::string _nextStateName);`
-- `void SetNextState(AnimationState* _nextStat);`
-- `std::string GetCurState();`
-- `std::string GetNextState();`
-- `bool CheckTransiton(bool isBlend = false);`
-- `nlohmann::json Serialize();`
-- `AniTransition Deserialize();`
-- `std::vector<TransCondition> GetConditions();`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `AniTransition` | ani transition 동작을 수행합니다. |
+| `~AniTransition` | ani transition 동작을 수행합니다. |
+| `DeleteCondition` | delete condition 동작을 수행합니다. |
+| `SetCurState` | cur state을(를) 설정합니다. |
+| `SetNextState` | next state을(를) 설정합니다. |
+| `GetCurState` | cur state을(를) 가져옵니다. |
+| `GetNextState` | next state을(를) 가져옵니다. |
+| `CheckTransiton` | check transiton 동작을 수행합니다. |
+| `Serialize` | serialize 동작을 수행합니다. |
+| `Deserialize` | deserialize 동작을 수행합니다. |
+| `GetConditions` | conditions을(를) 가져옵니다. |
 ## Public Properties
-- `std::string m_name = "NoName";`
-- `AnimationState* curState = nullptr;`
-- `AnimationState* nextState = nullptr;`
-- `float exitTime = 0.1f;`
-- `float blendTime = 0.2f;`
-- `bool hasExitTime = false;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `m_name` | m name 상태를 보관합니다. |
+| `curState` | cur state 상태를 보관합니다. |
+| `nextState` | next state 상태를 보관합니다. |
+| `exitTime` | exit time 상태를 보관합니다. |
+| `blendTime` | blend time 상태를 보관합니다. |
+| `hasExitTime` | has exit time 상태를 보관합니다. |

--- a/API_DOCS/AnimationBehviourFatory.md
+++ b/API_DOCS/AnimationBehviourFatory.md
@@ -7,7 +7,12 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `std::unordered_map<std::string, std::function<AniBehavior* ()>> m_aniFactoryMap;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `m_aniFactoryMap` | m ani factory map 동작을 수행합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/AnimationController.md
+++ b/API_DOCS/AnimationController.md
@@ -5,47 +5,54 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `AnimationController() = default;`
-- `~AnimationController();`
-- `bool BlendingAnimation(float tick);`
-- `void SetCurState(std::string stateName);`
-- `void SetNextState(std::string stateName);`
-- `std::shared_ptr<AniTransition> CheckTransition();`
-- `void UpdateState();`
-- `void Update(float tick);`
-- `int GetAnimatonIndexformState(std::string stateName);`
-- `std::shared_ptr<AnimationState> GetAniState();`
-- `AnimationState* CreateState(const std::string& stateName, int animationIndex,bool isAny = false);`
-- `std::shared_ptr<AnimationState> CreateState_UI();`
-- `void DeleteState(std::string stateName);`
-- `void DeleteTransiton(const std::string& fromStateName, const std::string& toStateName);`
-- `AnimationState* FindState(std::string stateName);`
-- `AniTransition* CreateTransition(const std::string& curStateName, const std::string& nextStateName);`
-- `void CreateMask();`
-- `void ReCreateMask(AvatarMask* mask);`
-- `void DeleteAvatarMask();`
-- `nlohmann::json Serialize();`
-- `void Deserialize();`
-- `void SetUseLayer(bool _useLayer);`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `AnimationController` | animation controller 동작을 수행합니다. |
+| `~AnimationController` | animation controller 동작을 수행합니다. |
+| `BlendingAnimation` | blending animation 동작을 수행합니다. |
+| `SetCurState` | cur state을(를) 설정합니다. |
+| `SetNextState` | next state을(를) 설정합니다. |
+| `CheckTransition` | check transition 동작을 수행합니다. |
+| `UpdateState` | state을(를) 갱신합니다. |
+| `Update` | update을(를) 갱신합니다. |
+| `GetAnimatonIndexformState` | animaton indexform state을(를) 가져옵니다. |
+| `GetAniState` | ani state을(를) 가져옵니다. |
+| `CreateState` | state을(를) 생성합니다. |
+| `CreateState_UI` | state ui을(를) 생성합니다. |
+| `DeleteState` | delete state 동작을 수행합니다. |
+| `DeleteTransiton` | delete transiton 동작을 수행합니다. |
+| `FindState` | state을(를) 탐색합니다. |
+| `CreateTransition` | transition을(를) 생성합니다. |
+| `CreateMask` | mask을(를) 생성합니다. |
+| `ReCreateMask` | re create mask 동작을 수행합니다. |
+| `DeleteAvatarMask` | delete avatar mask 동작을 수행합니다. |
+| `Serialize` | serialize 동작을 수행합니다. |
+| `Deserialize` | deserialize 동작을 수행합니다. |
+| `SetUseLayer` | use layer을(를) 설정합니다. |
 ## Public Properties
-- `std::string name = "None";`
-- `AnimationState* m_curState = nullptr;`
-- `AnimationState* m_nextState = nullptr;`
-- `std::vector<std::shared_ptr<AnimationState>> StateVec;`
-- `std::unordered_map<std::string, std::weak_ptr<AnimationState>> m_nameToState;`
-- `std::set<std::string> StateNameSet;`
-- `NodeEditor* m_nodeEditor;`
-- `std::shared_ptr<AnimationState> m_anyState;`
-- `float m_timeElapsed;`
-- `float m_nextTimeElapsed;`
-- `float curAnimationProgress = 0.f;`
-- `float preCurAnimationProgress = 0.f;`
-- `float nextAnimationProgress = 0.f;`
-- `float preNextAnimationProgress = 0.f;`
-- `bool needBlend = false;`
-- `bool m_isBlend = false;`
-- `bool useController = true;`
-- `bool m_useLayer = true;`
-- `bool useMask = false;`
-- `bool endAnimation = false;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `name` | name 상태를 보관합니다. |
+| `m_curState` | m cur state 상태를 보관합니다. |
+| `m_nextState` | m next state 상태를 보관합니다. |
+| `StateVec` | state vec 상태를 보관합니다. |
+| `m_nameToState` | m name to state 상태를 보관합니다. |
+| `StateNameSet` | state name set 상태를 보관합니다. |
+| `m_nodeEditor` | m node editor 상태를 보관합니다. |
+| `m_anyState` | m any state 상태를 보관합니다. |
+| `m_timeElapsed` | m time elapsed 상태를 보관합니다. |
+| `m_nextTimeElapsed` | m next time elapsed 상태를 보관합니다. |
+| `curAnimationProgress` | cur animation progress 상태를 보관합니다. |
+| `preCurAnimationProgress` | pre cur animation progress 상태를 보관합니다. |
+| `nextAnimationProgress` | next animation progress 상태를 보관합니다. |
+| `preNextAnimationProgress` | pre next animation progress 상태를 보관합니다. |
+| `needBlend` | need blend 상태를 보관합니다. |
+| `m_isBlend` | m is blend 상태를 보관합니다. |
+| `useController` | use controller 상태를 보관합니다. |
+| `m_useLayer` | m use layer 상태를 보관합니다. |
+| `useMask` | use mask 상태를 보관합니다. |
+| `endAnimation` | end animation 상태를 보관합니다. |

--- a/API_DOCS/AnimationState.md
+++ b/API_DOCS/AnimationState.md
@@ -5,22 +5,28 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `AnimationState();`
-- `~AnimationState();`
-- `AnimationState(AnimationController* Owner, std::string name);`
-- `std::vector<AniTransition*> FindTransitions(const std::string& toStateName);`
-- `void SetBehaviour(std::string name, bool isReload = false);`
-- `void UpdateAnimationSpeed();`
-- `nlohmann::json Serialize();`
-- `AnimationState Deserialize();`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `AnimationState` | animation state 동작을 수행합니다. |
+| `~AnimationState` | animation state 동작을 수행합니다. |
+| `FindTransitions` | transitions을(를) 탐색합니다. |
+| `SetBehaviour` | behaviour을(를) 설정합니다. |
+| `UpdateAnimationSpeed` | animation speed을(를) 갱신합니다. |
+| `Serialize` | serialize 동작을 수행합니다. |
+| `Deserialize` | deserialize 동작을 수행합니다. |
 ## Public Properties
-- `std::vector<std::shared_ptr<AniTransition>> Transitions;`
-- `int index =0;`
-- `int AnimationIndex = 0;`
-- `float animationSpeed = 1;`
-- `float multiplerAnimationSpeed = 1;`
-- `std::string animationSpeedParameterName = "None";`
-- `float m_animationTimeElapsed = 0;`
-- `bool m_isAny = false;`
-- `bool useMultipler = false;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `Transitions` | transitions 상태를 보관합니다. |
+| `index` | index 상태를 보관합니다. |
+| `AnimationIndex` | animation index 상태를 보관합니다. |
+| `animationSpeed` | animation speed 상태를 보관합니다. |
+| `multiplerAnimationSpeed` | multipler animation speed 상태를 보관합니다. |
+| `animationSpeedParameterName` | animation speed parameter name 상태를 보관합니다. |
+| `m_animationTimeElapsed` | m animation time elapsed 상태를 보관합니다. |
+| `m_isAny` | m is any 상태를 보관합니다. |
+| `useMultipler` | use multipler 상태를 보관합니다. |

--- a/API_DOCS/Animator.md
+++ b/API_DOCS/Animator.md
@@ -7,37 +7,43 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `void Awake() override;`
-- `void Update(float tick) override;`
-- `void OnDestroy() override;`
-- `void SetAnimation(int index);`
-- `void UpdateAnimation();`
-- `void CreateController(std::string name);`
-- `std::shared_ptr<AnimationController> CreateController_UI();`
-- `std::shared_ptr<AnimationController> CreateController_UINoAni();`
-- `void DeleteController(int index);`
-- `void DeleteController(std::string controllerName);`
-- `AnimationController* GetController(std::string name);`
-- `void SerializeControllers(std::string _jsonName);`
-- `void DeserializeControllers(std::string _filename);`
-- `void SetUseLayer(int layerindex,bool _useLayer);`
-- `GameObject* FindBoneRecursive(GameObject* parent, const std::string& boneName);`
-- `Socket* MakeSocket(std::string_view socketName,std::string_view boneName, GameObject* object);`
-- `Socket* FindSocket(std::string_view socketName);`
-- `void ClearControllersAndParams();`
-- `void AddParameter(const std::string valuename, T value, ValueType vType);`
-- `void DeleteParameter(int index);`
-- `ConditionParameter* AddDefaultParameter(ValueType vType);`
-- `void SetParameter(const std::string valuename, T Value);`
-- `ConditionParameter* FindParameter(std::string valueName);`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `Awake` | awake 동작을 수행합니다. |
+| `Update` | update을(를) 갱신합니다. |
+| `OnDestroy` | on destroy 동작을 수행합니다. |
+| `SetAnimation` | animation을(를) 설정합니다. |
+| `UpdateAnimation` | animation을(를) 갱신합니다. |
+| `CreateController` | controller을(를) 생성합니다. |
+| `CreateController_UI` | controller ui을(를) 생성합니다. |
+| `CreateController_UINoAni` | controller uino ani을(를) 생성합니다. |
+| `DeleteController` | delete controller 동작을 수행합니다. |
+| `GetController` | controller을(를) 가져옵니다. |
+| `SerializeControllers` | serialize controllers 동작을 수행합니다. |
+| `DeserializeControllers` | deserialize controllers 동작을 수행합니다. |
+| `SetUseLayer` | use layer을(를) 설정합니다. |
+| `FindBoneRecursive` | bone recursive을(를) 탐색합니다. |
+| `MakeSocket` | make socket 동작을 수행합니다. |
+| `FindSocket` | socket을(를) 탐색합니다. |
+| `ClearControllersAndParams` | controllers and params을(를) 비웁니다. |
+| `AddParameter` | parameter을(를) 추가합니다. |
+| `DeleteParameter` | delete parameter 동작을 수행합니다. |
+| `AddDefaultParameter` | default parameter을(를) 추가합니다. |
+| `SetParameter` | parameter을(를) 설정합니다. |
+| `FindParameter` | parameter을(를) 탐색합니다. |
 ## Public Properties
-- `float blendT = 0;`
-- `int nextAnimIndex = -1;`
-- `XMMATRIX blendtransform;`
-- `std::vector<Socket*> socketvec;`
-- `std::vector<ConditionParameter*> Parameters;`
-- `std::mutex m_paramMutex;`
-- `bool m_isBlend = false;`
-- `float m_stopTimer = 0.f;`
-- `float m_stopDuration = 0.f;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `blendT` | blend t 상태를 보관합니다. |
+| `nextAnimIndex` | next anim index 상태를 보관합니다. |
+| `blendtransform` | blendtransform 상태를 보관합니다. |
+| `socketvec` | socketvec 상태를 보관합니다. |
+| `Parameters` | parameters 상태를 보관합니다. |
+| `m_paramMutex` | m param mutex 상태를 보관합니다. |
+| `m_isBlend` | m is blend 상태를 보관합니다. |
+| `m_stopTimer` | m stop timer 상태를 보관합니다. |
+| `m_stopDuration` | m stop duration 상태를 보관합니다. |

--- a/API_DOCS/ArticulationData.md
+++ b/API_DOCS/ArticulationData.md
@@ -5,8 +5,13 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `ArticulationData() = default;`
-- `~ArticulationData() = default;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `ArticulationData` | articulation data 동작을 수행합니다. |
+| `~ArticulationData` | articulation data 동작을 수행합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/ArticulationLoader.md
+++ b/API_DOCS/ArticulationLoader.md
@@ -5,9 +5,13 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `void Save(const ArticulationData* data, const std::string& path);`
-- `ArticulationData* Load(const std::string& path);`
-- `ArticulationData* Load(const std::string& path,unsigned int& numbuer);`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `Save` | save을(를) 저장합니다. |
+| `Load` | load을(를) 불러옵니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/AvatarMask.md
+++ b/API_DOCS/AvatarMask.md
@@ -5,16 +5,22 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `AvatarMask() = default;`
-- `~AvatarMask();`
-- `bool IsBoneEnabled(BoneRegion region);`
-- `void ReCreateMask(AvatarMask* _otherMask);`
-- `bool IsBoneEnabled(const std::string& name);`
-- `BoneMask* MakeBoneMask(Bone* Bone);`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `AvatarMask` | avatar mask 동작을 수행합니다. |
+| `~AvatarMask` | avatar mask 동작을 수행합니다. |
+| `IsBoneEnabled` | bone enabled 여부를 확인합니다. |
+| `ReCreateMask` | re create mask 동작을 수행합니다. |
+| `MakeBoneMask` | make bone mask 동작을 수행합니다. |
 ## Public Properties
-- `std::vector<BoneMask*> m_BoneMasks;`
-- `bool isHumanoid = true;`
-- `bool useAll = false;`
-- `bool useUpper = true;`
-- `bool useLower = true;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `m_BoneMasks` | m bone masks 상태를 보관합니다. |
+| `isHumanoid` | humanoid 여부를 확인합니다. |
+| `useAll` | use all 상태를 보관합니다. |
+| `useUpper` | use upper 상태를 보관합니다. |
+| `useLower` | use lower 상태를 보관합니다. |

--- a/API_DOCS/BTNode.md
+++ b/API_DOCS/BTNode.md
@@ -7,10 +7,17 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `BTNode() = default;`
-- `virtual ~BTNode() = default;`
-- `virtual NodeStatus Tick(float deltatime,BlackBoard& blackBoard) = 0;`
-- `virtual BehaviorNodeType GetNodeType() const = 0;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `BTNode` | btnode 동작을 수행합니다. |
+| `~BTNode` | btnode 동작을 수행합니다. |
+| `Tick` | tick 동작을 수행합니다. |
+| `GetNodeType` | node type을(를) 가져옵니다. |
 ## Public Properties
-- `using NodePtr = std::shared_ptr<BTNode>;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `NodePtr` | node ptr 상태를 보관합니다. |

--- a/API_DOCS/BehaviorNodeType.md
+++ b/API_DOCS/BehaviorNodeType.md
@@ -5,7 +5,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/BehaviorTreeComponent.md
+++ b/API_DOCS/BehaviorTreeComponent.md
@@ -8,15 +8,22 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `void Initialize() override;`
-- `void Awake() override;`
-- `void InternalAIUpdate(float deltaSecond) override;`
-- `void OnDestroy() override;`
-- `BlackBoard* GetBlackBoard();`
-- `void GraphToBuild();`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `Initialize` | initialize 동작을 수행합니다. |
+| `Awake` | awake 동작을 수행합니다. |
+| `InternalAIUpdate` | internal aiupdate 동작을 수행합니다. |
+| `OnDestroy` | on destroy 동작을 수행합니다. |
+| `GetBlackBoard` | black board을(를) 가져옵니다. |
+| `GraphToBuild` | graph to build 동작을 수행합니다. |
 ## Public Properties
-- `std::string name;`
-- `std::string blackBoardName;`
-- `FileGuid m_BehaviorTreeGuid;`
-- `FileGuid m_BlackBoardGuid;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `name` | name 상태를 보관합니다. |
+| `blackBoardName` | black board name 상태를 보관합니다. |
+| `m_BehaviorTreeGuid` | m behavior tree guid 상태를 보관합니다. |
+| `m_BlackBoardGuid` | m black board guid 상태를 보관합니다. |

--- a/API_DOCS/BlackBoard.md
+++ b/API_DOCS/BlackBoard.md
@@ -5,32 +5,37 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `void SetValueAsBool(const std::string& key, bool value);`
-- `void SetValueAsInt(const std::string& key, int value);`
-- `void SetValueAsFloat(const std::string& key, float value);`
-- `void SetValueAsString(const std::string& key, const std::string& value);`
-- `void SetValueAsVector2(const std::string& key, const Mathf::Vector2& value);`
-- `void SetValueAsVector3(const std::string& key, const Mathf::Vector3& value);`
-- `void SetValueAsVector4(const std::string& key, const Mathf::Vector4& value);`
-- `void SetValueAsGameObject(const std::string& key, const std::string& objectName);`
-- `void SetValueAsTransform(const std::string& key, const std::string& transformPath);`
-- `bool GetValueAsBool(const std::string& key) const;`
-- `int GetValueAsInt(const std::string& key) const;`
-- `float GetValueAsFloat(const std::string& key) const;`
-- `const std::string& GetValueAsString(const std::string& key) const;`
-- `const Mathf::Vector2& GetValueAsVector2(const std::string& key) const;`
-- `const Mathf::Vector3& GetValueAsVector3(const std::string& key) const;`
-- `const Mathf::Vector4& GetValueAsVector4(const std::string& key) const;`
-- `GameObject* GetValueAsGameObject(const std::string& key) const;`
-- `const Transform& GetValueAsTransform(const std::string& key) const;`
-- `void AddKey(const std::string& key, const BlackBoardType& type);`
-- `bool HasKey(const std::string& key) const;`
-- `BlackBoardType GetType(const std::string& key) const;`
-- `void RemoveKey(const std::string& key);`
-- `void RenameKey(const std::string& curKey, const std::string& newKey);`
-- `void Clear();`
-- `void Serialize(std::string_view name);`
-- `void Deserialize(std::string_view name);`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `SetValueAsBool` | value as bool을(를) 설정합니다. |
+| `SetValueAsInt` | value as int을(를) 설정합니다. |
+| `SetValueAsFloat` | value as float을(를) 설정합니다. |
+| `SetValueAsString` | value as string을(를) 설정합니다. |
+| `SetValueAsVector2` | value as vector2을(를) 설정합니다. |
+| `SetValueAsVector3` | value as vector3을(를) 설정합니다. |
+| `SetValueAsVector4` | value as vector4을(를) 설정합니다. |
+| `SetValueAsGameObject` | value as game object을(를) 설정합니다. |
+| `SetValueAsTransform` | value as transform을(를) 설정합니다. |
+| `GetValueAsBool` | value as bool을(를) 가져옵니다. |
+| `GetValueAsInt` | value as int을(를) 가져옵니다. |
+| `GetValueAsFloat` | value as float을(를) 가져옵니다. |
+| `GetValueAsString` | value as string을(를) 가져옵니다. |
+| `GetValueAsVector2` | value as vector2을(를) 가져옵니다. |
+| `GetValueAsVector3` | value as vector3을(를) 가져옵니다. |
+| `GetValueAsVector4` | value as vector4을(를) 가져옵니다. |
+| `GetValueAsGameObject` | value as game object을(를) 가져옵니다. |
+| `GetValueAsTransform` | value as transform을(를) 가져옵니다. |
+| `AddKey` | key을(를) 추가합니다. |
+| `HasKey` | has key 동작을 수행합니다. |
+| `GetType` | type을(를) 가져옵니다. |
+| `RemoveKey` | key을(를) 제거합니다. |
+| `RenameKey` | rename key 동작을 수행합니다. |
+| `Clear` | clear을(를) 비웁니다. |
+| `Serialize` | serialize 동작을 수행합니다. |
+| `Deserialize` | deserialize 동작을 수행합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/BlackBoardType.md
+++ b/API_DOCS/BlackBoardType.md
@@ -5,7 +5,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/BoneMask.md
+++ b/API_DOCS/BoneMask.md
@@ -5,9 +5,16 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `BoneMask() = default;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `BoneMask` | bone mask 동작을 수행합니다. |
 ## Public Properties
-- `std::string boneName;`
-- `std::vector<BoneMask*> m_children;`
-- `bool isEnabled = true;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `boneName` | bone name 상태를 보관합니다. |
+| `m_children` | m children 상태를 보관합니다. |
+| `isEnabled` | enabled 여부를 확인합니다. |

--- a/API_DOCS/BoxColliderComponent.md
+++ b/API_DOCS/BoxColliderComponent.md
@@ -7,15 +7,22 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `virtual ~BoxColliderComponent() = default;`
-- `void SetPositionOffset(DirectX::SimpleMath::Vector3 pos) override;`
-- `DirectX::SimpleMath::Vector3 GetPositionOffset() override;`
-- `void SetRotationOffset(DirectX::SimpleMath::Quaternion rotation) override;`
-- `DirectX::SimpleMath::Quaternion GetRotationOffset() override;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `~BoxColliderComponent` | box collider component 동작을 수행합니다. |
+| `SetPositionOffset` | position offset을(를) 설정합니다. |
+| `GetPositionOffset` | position offset을(를) 가져옵니다. |
+| `SetRotationOffset` | rotation offset을(를) 설정합니다. |
+| `GetRotationOffset` | rotation offset을(를) 가져옵니다. |
 ## Public Properties
-- `float staticFriction = 0.5f;`
-- `float dynamicFriction = 0.4f;`
-- `float restitution = 0.3f;`
-- `float density = 10.0f;`
-- `BoxColliderInfo m_Info;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `staticFriction` | static friction 상태를 보관합니다. |
+| `dynamicFriction` | dynamic friction 상태를 보관합니다. |
+| `restitution` | restitution 상태를 보관합니다. |
+| `density` | density 상태를 보관합니다. |
+| `m_Info` | m info 상태를 보관합니다. |

--- a/API_DOCS/CSharpScriptComponent.md
+++ b/API_DOCS/CSharpScriptComponent.md
@@ -7,7 +7,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/CameraComponent.md
+++ b/API_DOCS/CameraComponent.md
@@ -7,7 +7,12 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `virtual ~CameraComponent() = default;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `~CameraComponent` | camera component 동작을 수행합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/Canvas.md
+++ b/API_DOCS/Canvas.md
@@ -7,15 +7,22 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `Canvas();`
-- `~Canvas() = default;`
-- `void OnDestroy() override;`
-- `void AddUIObject(std::shared_ptr<GameObject> obj);`
-- `virtual void Update(float tick) override;`
-- `std::weak_ptr<GameObject> GetFrontUIObject();`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `Canvas` | canvas 동작을 수행합니다. |
+| `~Canvas` | canvas 동작을 수행합니다. |
+| `OnDestroy` | on destroy 동작을 수행합니다. |
+| `AddUIObject` | uiobject을(를) 추가합니다. |
+| `Update` | update을(를) 갱신합니다. |
+| `GetFrontUIObject` | front uiobject을(를) 가져옵니다. |
 ## Public Properties
-- `int PreCanvasOrder = 0;`
-- `int CanvasOrder = 0;`
-- `std::vector<std::weak_ptr<GameObject>> UIObjs;`
-- `std::string CanvasName = "Canvas";`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `PreCanvasOrder` | pre canvas order 상태를 보관합니다. |
+| `CanvasOrder` | canvas order 상태를 보관합니다. |
+| `UIObjs` | uiobjs 상태를 보관합니다. |
+| `CanvasName` | canvas name 상태를 보관합니다. |

--- a/API_DOCS/CapsuleColliderComponent.md
+++ b/API_DOCS/CapsuleColliderComponent.md
@@ -7,16 +7,23 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `virtual ~CapsuleColliderComponent() = default;`
-- `void OnTriggerEnter(ICollider* other) override;`
-- `void OnTriggerStay(ICollider* other) override;`
-- `void OnTriggerExit(ICollider* other) override;`
-- `void OnCollisionEnter(ICollider* other) override;`
-- `void OnCollisionStay(ICollider* other) override;`
-- `void OnCollisionExit(ICollider* other) override;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `~CapsuleColliderComponent` | capsule collider component 동작을 수행합니다. |
+| `OnTriggerEnter` | on trigger enter 동작을 수행합니다. |
+| `OnTriggerStay` | on trigger stay 동작을 수행합니다. |
+| `OnTriggerExit` | on trigger exit 동작을 수행합니다. |
+| `OnCollisionEnter` | on collision enter 동작을 수행합니다. |
+| `OnCollisionStay` | on collision stay 동작을 수행합니다. |
+| `OnCollisionExit` | on collision exit 동작을 수행합니다. |
 ## Public Properties
-- `float staticFriction = 0.5f;`
-- `float dynamicFriction = 0.4f;`
-- `float restitution = 0.3f;`
-- `float density = 10.0f;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `staticFriction` | static friction 상태를 보관합니다. |
+| `dynamicFriction` | dynamic friction 상태를 보관합니다. |
+| `restitution` | restitution 상태를 보관합니다. |
+| `density` | density 상태를 보관합니다. |

--- a/API_DOCS/ChannelType.md
+++ b/API_DOCS/ChannelType.md
@@ -5,7 +5,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/CharacterControllerComponent.md
+++ b/API_DOCS/CharacterControllerComponent.md
@@ -7,23 +7,30 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `void OnStart();`
-- `void OnFixedUpdate(float fixedDeltaTime);`
-- `void OnLateUpdate(float fixedDeltaTime);`
-- `void ForcedSetPosition(const DirectX::SimpleMath::Vector3& pos);`
-- `void SetAutomaticRotation(bool useAuto);`
-- `void TriggerForcedMove(const DirectX::SimpleMath::Vector3& initialVelocity, float duration=0.0f, Mathf::Easing::EaseType curveType = Mathf::Easing::EaseType::None);`
-- `void StopForcedMove();`
-- `bool IsInForcedMove() const;`
-- `void SetLookDirection(const DirectX::SimpleMath::Vector3& direction);`
-- `void ClearLookDirection();`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `OnStart` | on start 동작을 수행합니다. |
+| `OnFixedUpdate` | on fixed update 동작을 수행합니다. |
+| `OnLateUpdate` | on late update 동작을 수행합니다. |
+| `ForcedSetPosition` | forced set position 동작을 수행합니다. |
+| `SetAutomaticRotation` | automatic rotation을(를) 설정합니다. |
+| `TriggerForcedMove` | trigger forced move 동작을 수행합니다. |
+| `StopForcedMove` | stop forced move 동작을 수행합니다. |
+| `IsInForcedMove` | in forced move 여부를 확인합니다. |
+| `SetLookDirection` | look direction을(를) 설정합니다. |
+| `ClearLookDirection` | look direction을(를) 비웁니다. |
 ## Public Properties
-- `float m_radius = 0.55f;`
-- `float m_height = 2.f;`
-- `float maxSpeed = 1.025f;`
-- `float acceleration = 1.0f;`
-- `float staticFriction = 0.4f;`
-- `float dynamicFriction = 0.1f;`
-- `float jumpSpeed = 0.05f;`
-- `float gravityWeight = 0.2f;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `m_radius` | m radius 상태를 보관합니다. |
+| `m_height` | m height 상태를 보관합니다. |
+| `maxSpeed` | max speed 상태를 보관합니다. |
+| `acceleration` | acceleration 상태를 보관합니다. |
+| `staticFriction` | static friction 상태를 보관합니다. |
+| `dynamicFriction` | dynamic friction 상태를 보관합니다. |
+| `jumpSpeed` | jump speed 상태를 보관합니다. |
+| `gravityWeight` | gravity weight 상태를 보관합니다. |

--- a/API_DOCS/ClipDirection.md
+++ b/API_DOCS/ClipDirection.md
@@ -7,7 +7,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/Component.md
+++ b/API_DOCS/Component.md
@@ -7,10 +7,14 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `void SetOwner(GameObject* owner);`
-- `T* GetComponent();`
-- `T* GetComponentDynamicCast();`
-- `Component& GetComponent(HashedGuid typeof);`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `SetOwner` | owner을(를) 설정합니다. |
+| `GetComponent` | component을(를) 가져옵니다. |
+| `GetComponentDynamicCast` | component dynamic cast을(를) 가져옵니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/ComponentFactory.md
+++ b/API_DOCS/ComponentFactory.md
@@ -7,8 +7,13 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `void Initialize();`
-- `void LoadComponent(GameObject* obj, const MetaYml::detail::iterator_value& itNode, bool isEditorToGame = false);`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `Initialize` | initialize 동작을 수행합니다. |
+| `LoadComponent` | component을(를) 불러옵니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/CompositeNode.md
+++ b/API_DOCS/CompositeNode.md
@@ -7,8 +7,13 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `CompositeNode() = default;`
-- `~CompositeNode() override = default;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `CompositeNode` | composite node 동작을 수행합니다. |
+| `~CompositeNode` | composite node 동작을 수행합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/ConditionDecoratorNode.md
+++ b/API_DOCS/ConditionDecoratorNode.md
@@ -7,10 +7,15 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `using ConditionFunc = std::function<bool(float, const BlackBoard&)>;`
-- `ConditionDecoratorNode() = default;`
-- `~ConditionDecoratorNode() override = default;`
-- `virtual bool ConditionCheck(float deltatime, const BlackBoard& blackBoard) abstract;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `ConditionFunc` | condition func 동작을 수행합니다. |
+| `ConditionDecoratorNode` | condition decorator node 동작을 수행합니다. |
+| `~ConditionDecoratorNode` | condition decorator node 동작을 수행합니다. |
+| `ConditionCheck` | condition check 동작을 수행합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/ConditionNode.md
+++ b/API_DOCS/ConditionNode.md
@@ -7,9 +7,14 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `ConditionNode() = default;`
-- `~ConditionNode() override = default;`
-- `virtual bool ConditionCheck(float deltatime, const BlackBoard& blackBoard) abstract;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `ConditionNode` | condition node 동작을 수행합니다. |
+| `~ConditionNode` | condition node 동작을 수행합니다. |
+| `ConditionCheck` | condition check 동작을 수행합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/ConditionParameter.md
+++ b/API_DOCS/ConditionParameter.md
@@ -5,10 +5,17 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `ConditionParameter() = default;`
-- `nlohmann::json Serialize();`
-- `void Deserialize();`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `ConditionParameter` | condition parameter 동작을 수행합니다. |
+| `Serialize` | serialize 동작을 수행합니다. |
+| `Deserialize` | deserialize 동작을 수행합니다. |
 ## Public Properties
-- `std::string name = "None";`
-- `ValueType vType =ValueType::Float;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `name` | name 상태를 보관합니다. |
+| `vType` | v type 상태를 보관합니다. |

--- a/API_DOCS/ConditionType.md
+++ b/API_DOCS/ConditionType.md
@@ -5,7 +5,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/DecalComponent.md
+++ b/API_DOCS/DecalComponent.md
@@ -7,21 +7,25 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `void Awake() override;`
-- `void Update(float deltaSeconds) override;`
-- `void OnDestroy() override;`
-- `void SetDecalTexture(const std::string_view& fileName);`
-- `void SetDecalTexture(const FileGuid& fileGuid);`
-- `void SetNormalTexture(const std::string_view& fileName);`
-- `void SetNormalTexture(const FileGuid& fileGuid);`
-- `void SetORMTexture(const std::string_view& fileName);`
-- `void SetORMTexture(const FileGuid& fileGuid);`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `Awake` | awake 동작을 수행합니다. |
+| `Update` | update을(를) 갱신합니다. |
+| `OnDestroy` | on destroy 동작을 수행합니다. |
+| `SetDecalTexture` | decal texture을(를) 설정합니다. |
+| `SetNormalTexture` | normal texture을(를) 설정합니다. |
+| `SetORMTexture` | ormtexture을(를) 설정합니다. |
 ## Public Properties
-- `uint32 sliceX = 1;`
-- `uint32 sliceY = 1;`
-- `int sliceNumber = 0;`
-- `float slicePerSeconds = 1.f;`
-- `float timer = 0.f;`
-- `bool useAnimation = false;`
-- `bool isLoop = true;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `sliceX` | slice x 상태를 보관합니다. |
+| `sliceY` | slice y 상태를 보관합니다. |
+| `sliceNumber` | slice number 상태를 보관합니다. |
+| `slicePerSeconds` | slice per seconds 상태를 보관합니다. |
+| `timer` | timer 상태를 보관합니다. |
+| `useAnimation` | use animation 상태를 보관합니다. |
+| `isLoop` | loop 여부를 확인합니다. |

--- a/API_DOCS/DecoratorNode.md
+++ b/API_DOCS/DecoratorNode.md
@@ -7,8 +7,13 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `DecoratorNode() = default;`
-- `~DecoratorNode() override = default;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `DecoratorNode` | decorator node 동작을 수행합니다. |
+| `~DecoratorNode` | decorator node 동작을 수행합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/Direction.md
+++ b/API_DOCS/Direction.md
@@ -5,7 +5,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/EBodyType.md
+++ b/API_DOCS/EBodyType.md
@@ -5,7 +5,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/EForceMode.md
+++ b/API_DOCS/EForceMode.md
@@ -5,7 +5,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/EShapeType.md
+++ b/API_DOCS/EShapeType.md
@@ -5,7 +5,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/EffectComponent.md
+++ b/API_DOCS/EffectComponent.md
@@ -7,28 +7,35 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `void Initialize() override;`
-- `void Update(float tick) override;`
-- `void OnDestroy() override;`
-- `void Apply();`
-- `void PlayPreview();`
-- `void StopEffect();`
-- `void PauseEffect();`
-- `void ResumeEffect();`
-- `void ChangeEffect(const std::string& newEffectName);`
-- `void PlayEffectByName(const std::string& effectName);`
-- `void SetLoop(bool loop);`
-- `void SetDuration(float duration);`
-- `void SetTimeScale(float timeScale);`
-- `void ForceFinishEffect();`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `Initialize` | initialize 동작을 수행합니다. |
+| `Update` | update을(를) 갱신합니다. |
+| `OnDestroy` | on destroy 동작을 수행합니다. |
+| `Apply` | apply을(를) 적용합니다. |
+| `PlayPreview` | play preview 동작을 수행합니다. |
+| `StopEffect` | stop effect 동작을 수행합니다. |
+| `PauseEffect` | pause effect 동작을 수행합니다. |
+| `ResumeEffect` | resume effect 동작을 수행합니다. |
+| `ChangeEffect` | change effect 동작을 수행합니다. |
+| `PlayEffectByName` | play effect by name 동작을 수행합니다. |
+| `SetLoop` | loop을(를) 설정합니다. |
+| `SetDuration` | duration을(를) 설정합니다. |
+| `SetTimeScale` | time scale을(를) 설정합니다. |
+| `ForceFinishEffect` | force finish effect 동작을 수행합니다. |
 ## Public Properties
-- `std::string m_effectTemplateName = "Null";`
-- `float m_timeScale = 1.0f;`
-- `float m_duration = -1.0f;`
-- `bool m_isPlaying = false;`
-- `bool m_isPaused = false;`
-- `bool m_loop = true;`
-- `bool m_useAbsolutePosition = false;`
-- `float m_currentTime = 0;`
-- `std::string m_effectInstanceName;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `m_effectTemplateName` | m effect template name 상태를 보관합니다. |
+| `m_timeScale` | m time scale 상태를 보관합니다. |
+| `m_duration` | m duration 상태를 보관합니다. |
+| `m_isPlaying` | m is playing 상태를 보관합니다. |
+| `m_isPaused` | m is paused 상태를 보관합니다. |
+| `m_loop` | m loop 상태를 보관합니다. |
+| `m_useAbsolutePosition` | m use absolute position 상태를 보관합니다. |
+| `m_currentTime` | m current time 상태를 보관합니다. |
+| `m_effectInstanceName` | m effect instance name 상태를 보관합니다. |

--- a/API_DOCS/FSMState.md
+++ b/API_DOCS/FSMState.md
@@ -7,7 +7,12 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `virtual ~FSMState() = default;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `~FSMState` | fsmstate 동작을 수행합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/FoliageComponent.md
+++ b/API_DOCS/FoliageComponent.md
@@ -7,19 +7,24 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `void Awake() override;`
-- `void Update(float deltaTime) override;`
-- `void OnDestroy() override;`
-- `void SaveFoliageAsset(const file::path& savePath);`
-- `void LoadFoliageAsset(FileGuid assetGuid);`
-- `void AddFoliageType(const FoliageType& type);`
-- `void RemoveFoliageType(uint32 typeID);`
-- `void AddFoliageInstance(const FoliageInstance& instance);`
-- `void RemoveFoliageInstance(size_t index);`
-- `void AddInstanceFromTerrain(TerrainComponent* terrain, const FoliageInstance& instance);`
-- `void AddRandomInstancesInBrush(TerrainComponent* terrain, const TerrainBrush& brush, uint32 typeID, int count);`
-- `void RemoveInstancesInBrush(TerrainComponent* terrain, const TerrainBrush& brush);`
-- `void UpdateFoliageCullingData(Camera* camera);`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `Awake` | awake 동작을 수행합니다. |
+| `Update` | update을(를) 갱신합니다. |
+| `OnDestroy` | on destroy 동작을 수행합니다. |
+| `SaveFoliageAsset` | foliage asset을(를) 저장합니다. |
+| `LoadFoliageAsset` | foliage asset을(를) 불러옵니다. |
+| `AddFoliageType` | foliage type을(를) 추가합니다. |
+| `RemoveFoliageType` | foliage type을(를) 제거합니다. |
+| `AddFoliageInstance` | foliage instance을(를) 추가합니다. |
+| `RemoveFoliageInstance` | foliage instance을(를) 제거합니다. |
+| `AddInstanceFromTerrain` | instance from terrain을(를) 추가합니다. |
+| `AddRandomInstancesInBrush` | random instances in brush을(를) 추가합니다. |
+| `RemoveInstancesInBrush` | instances in brush을(를) 제거합니다. |
+| `UpdateFoliageCullingData` | foliage culling data을(를) 갱신합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/FoliageMode.md
+++ b/API_DOCS/FoliageMode.md
@@ -5,7 +5,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/FunctionRegistry.md
+++ b/API_DOCS/FunctionRegistry.md
@@ -5,7 +5,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/GameObject.md
+++ b/API_DOCS/GameObject.md
@@ -7,51 +7,48 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `static constexpr GameObject::Index INVALID_INDEX = std::numeric_limits<uint32_t>::max();`
-- `GameObject();`
-- `GameObject(Scene* scene, std::string_view name, GameObjectType type, GameObject::Index index, GameObject::Index parentIndex);`
-- `GameObject(Scene* scene, size_t instanceID, std::string_view name, GameObjectType type, GameObject::Index index, GameObject::Index parentIndex);`
-- `GameObject(GameObject&) = delete;`
-- `GameObject(GameObject&&) noexcept = default;`
-- `GameObject& operator=(GameObject&) = delete;`
-- `~GameObject() override = default;`
-- `const std::string& RemoveSuffixNumberTag() const;`
-- `void SetTag(std::string_view tag);`
-- `void SetLayer(std::string_view layer);`
-- `virtual void Destroy() override final;`
-- `std::shared_ptr<Component> AddComponent(const Meta::Type& type);`
-- `ModuleBehavior* AddScriptComponent(std::string_view scriptName);`
-- `std::shared_ptr<Component> GetComponent(const Meta::Type& type);`
-- `std::shared_ptr<Component> GetComponentByTypeID(uint32 id);`
-- `void RefreshComponentIdIndices();`
-- `void AddChild(GameObject* _objcet);`
-- `T* AddComponent();`
-- `T* AddComponent(Args&&... args);`
-- `T* GetComponent(uint32 id);`
-- `T* GetComponent();`
-- `T* GetComponentDynamicCast();`
-- `std::vector<T*> GetComponentsInChildren();`
-- `std::vector<T*> GetComponentsInchildrenDynamicCast();`
-- `bool HasComponent();`
-- `std::vector<T*> GetComponents();`
-- `void RemoveComponent(T* component);`
-- `void RemoveComponentIndex(uint32 id);`
-- `void RemoveComponentTypeID(uint32 typeID);`
-- `void RemoveScriptComponent(std::string_view scriptName);`
-- `void RemoveScriptComponent(ModuleBehavior* ptr);`
-- `void RemoveComponent(Meta::Type& type);`
-- `static GameObject* Find(std::string_view name);`
-- `static GameObject* FindIndex(GameObject::Index index);`
-- `static GameObject* FindInstanceID(const HashedGuid& guid);`
-- `static GameObject* FindAttachedID(const HashedGuid& guid);`
-- `GameObject* OwnerSceneFind(std::string_view name);`
-- `GameObject* OwnerSceneFindIndex(GameObject::Index index);`
-- `GameObject* OwnerSceneFindInstanceID(const HashedGuid& guid);`
-- `GameObject* OwnerSceneFindAttachedID(const HashedGuid& guid);`
-- `void SetEnabled(bool able) override final;`
-- `void SetCollisionType();`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `INVALID_INDEX` | invalid index 동작을 수행합니다. |
+| `GameObject` | game object 동작을 수행합니다. |
+| `operator` | operator 동작을 수행합니다. |
+| `~GameObject` | game object 동작을 수행합니다. |
+| `RemoveSuffixNumberTag` | suffix number tag을(를) 제거합니다. |
+| `SetTag` | tag을(를) 설정합니다. |
+| `SetLayer` | layer을(를) 설정합니다. |
+| `Destroy` | destroy을(를) 파괴합니다. |
+| `AddComponent` | component을(를) 추가합니다. |
+| `AddScriptComponent` | script component을(를) 추가합니다. |
+| `GetComponent` | component을(를) 가져옵니다. |
+| `GetComponentByTypeID` | component by type id을(를) 가져옵니다. |
+| `RefreshComponentIdIndices` | component id indices을(를) 새로 고칩니다. |
+| `AddChild` | child을(를) 추가합니다. |
+| `GetComponentDynamicCast` | component dynamic cast을(를) 가져옵니다. |
+| `GetComponentsInChildren` | components in children을(를) 가져옵니다. |
+| `GetComponentsInchildrenDynamicCast` | components inchildren dynamic cast을(를) 가져옵니다. |
+| `HasComponent` | has component 동작을 수행합니다. |
+| `GetComponents` | components을(를) 가져옵니다. |
+| `RemoveComponent` | component을(를) 제거합니다. |
+| `RemoveComponentIndex` | component index을(를) 제거합니다. |
+| `RemoveComponentTypeID` | component type id을(를) 제거합니다. |
+| `RemoveScriptComponent` | script component을(를) 제거합니다. |
+| `Find` | find을(를) 탐색합니다. |
+| `FindIndex` | index을(를) 탐색합니다. |
+| `FindInstanceID` | instance id을(를) 탐색합니다. |
+| `FindAttachedID` | attached id을(를) 탐색합니다. |
+| `OwnerSceneFind` | owner scene find 동작을 수행합니다. |
+| `OwnerSceneFindIndex` | owner scene find index 동작을 수행합니다. |
+| `OwnerSceneFindInstanceID` | owner scene find instance id 동작을 수행합니다. |
+| `OwnerSceneFindAttachedID` | owner scene find attached id 동작을 수행합니다. |
+| `SetEnabled` | enabled을(를) 설정합니다. |
+| `SetCollisionType` | collision type을(를) 설정합니다. |
 ## Public Properties
-- `using Index = int;`
-- `uint32 m_collisionType = 0;`
-- `std::vector<GameObject::Index> m_childrenIndices;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `Index` | index 상태를 보관합니다. |
+| `m_collisionType` | m collision type 상태를 보관합니다. |
+| `m_childrenIndices` | m children indices 상태를 보관합니다. |

--- a/API_DOCS/GameObjectType.md
+++ b/API_DOCS/GameObjectType.md
@@ -5,7 +5,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/HotLoadSystem.md
+++ b/API_DOCS/HotLoadSystem.md
@@ -7,26 +7,31 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `void Initialize();`
-- `void Shutdown();`
-- `bool IsScriptUpToDate();`
-- `void ReloadDynamicLibrary();`
-- `void ReplaceScriptComponent();`
-- `void ReplaceScriptComponentTargetScene(Scene* targetScene);`
-- `void CompileEvent();`
-- `void CreateScriptFile(std::string_view name);`
-- `void BindScriptEvents(ModuleBehavior* script, std::string_view name);`
-- `void UnbindScriptEvents(ModuleBehavior* script, std::string_view name);`
-- `void RegisterScriptReflection(std::string_view name, ModuleBehavior* script);`
-- `void UnRegisterScriptReflection(std::string_view name);`
-- `void RecollectScriptComponents(const std::vector<std::shared_ptr<GameObject>>& gameObjects);`
-- `void CreateActionNodeScript(std::string_view name);`
-- `void CreateConditionNodeScript(std::string_view name);`
-- `void CreateConditionDecoratorNodeScript(std::string_view name);`
-- `void CreateAniBehaviorScript(std::string_view name);`
-- `void CollectScriptComponent(GameObject* gameObject, size_t index, const std::string& name);`
-- `void UnCollectScriptComponent(GameObject* gameObject, size_t index, const std::string& name);`
-- `void ResetAniBehaviorPtr();`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `Initialize` | initialize 동작을 수행합니다. |
+| `Shutdown` | shutdown 동작을 수행합니다. |
+| `IsScriptUpToDate` | script up to date 여부를 확인합니다. |
+| `ReloadDynamicLibrary` | reload dynamic library 동작을 수행합니다. |
+| `ReplaceScriptComponent` | replace script component 동작을 수행합니다. |
+| `ReplaceScriptComponentTargetScene` | replace script component target scene 동작을 수행합니다. |
+| `CompileEvent` | compile event 동작을 수행합니다. |
+| `CreateScriptFile` | script file을(를) 생성합니다. |
+| `BindScriptEvents` | bind script events 동작을 수행합니다. |
+| `UnbindScriptEvents` | unbind script events 동작을 수행합니다. |
+| `RegisterScriptReflection` | register script reflection 동작을 수행합니다. |
+| `UnRegisterScriptReflection` | un register script reflection 동작을 수행합니다. |
+| `RecollectScriptComponents` | recollect script components 동작을 수행합니다. |
+| `CreateActionNodeScript` | action node script을(를) 생성합니다. |
+| `CreateConditionNodeScript` | condition node script을(를) 생성합니다. |
+| `CreateConditionDecoratorNodeScript` | condition decorator node script을(를) 생성합니다. |
+| `CreateAniBehaviorScript` | ani behavior script을(를) 생성합니다. |
+| `CollectScriptComponent` | collect script component 동작을 수행합니다. |
+| `UnCollectScriptComponent` | un collect script component 동작을 수행합니다. |
+| `ResetAniBehaviorPtr` | reset ani behavior ptr 동작을 수행합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/IAIComponent.md
+++ b/API_DOCS/IAIComponent.md
@@ -5,8 +5,13 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `virtual ~IAIComponent() = default;`
-- `virtual void Initialize() = 0;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `~IAIComponent` | iaicomponent 동작을 수행합니다. |
+| `Initialize` | initialize 동작을 수행합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/IRegistableEvent.md
+++ b/API_DOCS/IRegistableEvent.md
@@ -5,8 +5,13 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `virtual ~IRegistableEvent();`
-- `virtual void RegisterOverriddenEvents(Scene* scene) = 0;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `~IRegistableEvent` | iregistable event 동작을 수행합니다. |
+| `RegisterOverriddenEvents` | register overridden events 동작을 수행합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/IScriptedFSM.md
+++ b/API_DOCS/IScriptedFSM.md
@@ -5,10 +5,15 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `virtual ~IScriptedFSM() = default;`
-- `virtual void Enter(BlackBoard& bb) = 0;`
-- `virtual void Update(BlackBoard& bb, float deltaTime) = 0;`
-- `virtual void Exit(BlackBoard& bb) = 0;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `~IScriptedFSM` | iscripted fsm 동작을 수행합니다. |
+| `Enter` | enter 동작을 수행합니다. |
+| `Update` | update을(를) 갱신합니다. |
+| `Exit` | exit 동작을 수행합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/ISerializable.md
+++ b/API_DOCS/ISerializable.md
@@ -5,10 +5,15 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `virtual ~ISerializable() = default;`
-- `virtual nlohmann::json SerializeData() const = 0;`
-- `virtual void DeserializeData(const nlohmann::json& json) = 0;`
-- `virtual std::string GetModuleType() const = 0;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `~ISerializable` | iserializable 동작을 수행합니다. |
+| `SerializeData` | serialize data 동작을 수행합니다. |
+| `DeserializeData` | deserialize data 동작을 수행합니다. |
+| `GetModuleType` | module type을(를) 가져옵니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/ImageComponent.md
+++ b/API_DOCS/ImageComponent.md
@@ -7,17 +7,22 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `ImageComponent();`
-- `~ImageComponent() = default;`
-- `void Load(const std::shared_ptr<Texture>& ptr);`
-- `void DeserializeTexture(const std::shared_ptr<Texture>& ptr);`
-- `virtual void Awake() override;`
-- `virtual void Update(float tick) override;`
-- `virtual void OnDestroy() override;`
-- `void UpdateTexture();`
-- `void SetTexture(int index);`
-- `void ResetSize();`
-- `bool isThisTextureExist(std::string_view path) const;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `ImageComponent` | image component 동작을 수행합니다. |
+| `~ImageComponent` | image component 동작을 수행합니다. |
+| `Load` | load을(를) 불러옵니다. |
+| `DeserializeTexture` | deserialize texture 동작을 수행합니다. |
+| `Awake` | awake 동작을 수행합니다. |
+| `Update` | update을(를) 갱신합니다. |
+| `OnDestroy` | on destroy 동작을 수행합니다. |
+| `UpdateTexture` | texture을(를) 갱신합니다. |
+| `SetTexture` | texture을(를) 설정합니다. |
+| `ResetSize` | reset size 동작을 수행합니다. |
+| `isThisTextureExist` | this texture exist 여부를 확인합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/InputAction.md
+++ b/API_DOCS/InputAction.md
@@ -5,20 +5,26 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `InputAction() = default;`
-- `void SetControllerButton(ControllerButton _btn);`
-- `std::function<void()> buttonAction;`
-- `std::function<void(std::any)> valueAction;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `InputAction` | input action 동작을 수행합니다. |
+| `SetControllerButton` | controller button을(를) 설정합니다. |
+| `void` | void 동작을 수행합니다. |
 ## Public Properties
-- `std::string actionName;`
-- `InputType inputType= InputType::KeyBoard;`
-- `ActionType actionType = ActionType::Button;`
-- `KeyState  keystate  = KeyState::Down;`
-- `InputValueType valueType = InputValueType::Vector2;`
-- `size_t playerIndex = 0;`
-- `InputValue value;`
-- `std::string objName;`
-- `std::string m_scriptName  = "None";`
-- `std::string funName = "None";`
-- `ControllerButton m_controllerButton = ControllerButton::None;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `actionName` | action name 상태를 보관합니다. |
+| `inputType` | input type 상태를 보관합니다. |
+| `actionType` | action type 상태를 보관합니다. |
+| `keystate` | keystate 상태를 보관합니다. |
+| `valueType` | value type 상태를 보관합니다. |
+| `playerIndex` | player index 상태를 보관합니다. |
+| `value` | value 상태를 보관합니다. |
+| `objName` | obj name 상태를 보관합니다. |
+| `m_scriptName` | m script name 상태를 보관합니다. |
+| `funName` | fun name 상태를 보관합니다. |
+| `m_controllerButton` | m controller button 상태를 보관합니다. |

--- a/API_DOCS/InputActionManager.md
+++ b/API_DOCS/InputActionManager.md
@@ -5,16 +5,22 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `~InputActionManager() = default;`
-- `void Update(float tick);`
-- `void AddActionMap();`
-- `ActionMap* AddActionMap(std::string name);`
-- `void DeleteActionMap(std::string name);`
-- `ActionMap* FindActionMap(std::string name);`
-- `void SaveManager();`
-- `void LoadManager();`
-- `nlohmann::json SerializeMap(ActionMap* _actionMap);`
-- `ActionMap* DeSerializeMap(std::string _filepath);`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `~InputActionManager` | input action manager 동작을 수행합니다. |
+| `Update` | update을(를) 갱신합니다. |
+| `AddActionMap` | action map을(를) 추가합니다. |
+| `DeleteActionMap` | delete action map 동작을 수행합니다. |
+| `FindActionMap` | action map을(를) 탐색합니다. |
+| `SaveManager` | manager을(를) 저장합니다. |
+| `LoadManager` | manager을(를) 불러옵니다. |
+| `SerializeMap` | serialize map 동작을 수행합니다. |
+| `DeSerializeMap` | de serialize map 동작을 수행합니다. |
 ## Public Properties
-- `std::vector<ActionMap*> m_actionMaps;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `m_actionMaps` | m action maps 상태를 보관합니다. |

--- a/API_DOCS/InputManager.md
+++ b/API_DOCS/InputManager.md
@@ -7,38 +7,44 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `bool Initialize(HWND _hwnd);`
-- `void Update(float deltaTime);`
-- `void KeyBoardUpdate();`
-- `bool IsAnyKeyPressed();`
-- `void MouseUpdate();`
-- `void SetMousePos(POINT pos);`
-- `float2 GetMousePos();`
-- `float2 GetMouseDelta() const;`
-- `bool IsWheelUp();`
-- `bool IsWheelDown();`
-- `bool IsMouseButtonDown(MouseKey button);`
-- `bool IsMouseButtonPressed(MouseKey button);`
-- `bool IsMouseButtonReleased(MouseKey button);`
-- `void HideCursor();`
-- `void ShowCursor();`
-- `void ResetMouseDelta();`
-- `int16 GetWheelDelta() const;`
-- `void PadUpdate();`
-- `void GamePadUpdate();`
-- `bool IsControllerConnected(DWORD Index);`
-- `bool IsControllerButtonDown(DWORD index, ControllerButton btn) const;`
-- `bool IsControllerButtonPressed(DWORD index, ControllerButton btn) const;`
-- `bool IsControllerButtonReleased(DWORD index, ControllerButton btn) const;`
-- `bool IsControllerTriggerL(DWORD index) const;`
-- `bool IsControllerTriggerR(DWORD index) const;`
-- `Mathf::Vector2 GetControllerThumbL(DWORD index) const;`
-- `Mathf::Vector2 GetControllerThumbR(DWORD index) const;`
-- `void SetControllerVibration(DWORD Index, float leftMotorSpeed, float rightMotorSpeed, float lowFre, float highFre, float time);`
-- `void SetControllerVibration(DWORD Index, float leftMotorSpeed, float rightMotorSpeed, float lowFre, float highFre);`
-- `void UpdateControllerVibration(float tick);`
-- `void SetControllerVibrationTime(DWORD Index, float time);`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `Initialize` | initialize 동작을 수행합니다. |
+| `Update` | update을(를) 갱신합니다. |
+| `KeyBoardUpdate` | key board update 동작을 수행합니다. |
+| `IsAnyKeyPressed` | any key pressed 여부를 확인합니다. |
+| `MouseUpdate` | mouse update 동작을 수행합니다. |
+| `SetMousePos` | mouse pos을(를) 설정합니다. |
+| `GetMousePos` | mouse pos을(를) 가져옵니다. |
+| `GetMouseDelta` | mouse delta을(를) 가져옵니다. |
+| `IsWheelUp` | wheel up 여부를 확인합니다. |
+| `IsWheelDown` | wheel down 여부를 확인합니다. |
+| `IsMouseButtonDown` | mouse button down 여부를 확인합니다. |
+| `IsMouseButtonPressed` | mouse button pressed 여부를 확인합니다. |
+| `IsMouseButtonReleased` | mouse button released 여부를 확인합니다. |
+| `HideCursor` | hide cursor 동작을 수행합니다. |
+| `ShowCursor` | show cursor 동작을 수행합니다. |
+| `ResetMouseDelta` | reset mouse delta 동작을 수행합니다. |
+| `GetWheelDelta` | wheel delta을(를) 가져옵니다. |
+| `PadUpdate` | pad update 동작을 수행합니다. |
+| `GamePadUpdate` | game pad update 동작을 수행합니다. |
+| `IsControllerConnected` | controller connected 여부를 확인합니다. |
+| `IsControllerButtonDown` | controller button down 여부를 확인합니다. |
+| `IsControllerButtonPressed` | controller button pressed 여부를 확인합니다. |
+| `IsControllerButtonReleased` | controller button released 여부를 확인합니다. |
+| `IsControllerTriggerL` | controller trigger l 여부를 확인합니다. |
+| `IsControllerTriggerR` | controller trigger r 여부를 확인합니다. |
+| `GetControllerThumbL` | controller thumb l을(를) 가져옵니다. |
+| `GetControllerThumbR` | controller thumb r을(를) 가져옵니다. |
+| `SetControllerVibration` | controller vibration을(를) 설정합니다. |
+| `UpdateControllerVibration` | controller vibration을(를) 갱신합니다. |
+| `SetControllerVibrationTime` | controller vibration time을(를) 설정합니다. |
 ## Public Properties
-- `float							deadZone = 0.24f;`
-- `float							triggerdeadZone = 0.1f;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `deadZone` | dead zone 상태를 보관합니다. |
+| `triggerdeadZone` | triggerdead zone 상태를 보관합니다. |

--- a/API_DOCS/InputType.md
+++ b/API_DOCS/InputType.md
@@ -5,7 +5,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/InputValueType.md
+++ b/API_DOCS/InputValueType.md
@@ -5,7 +5,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/InvalidScriptComponent.md
+++ b/API_DOCS/InvalidScriptComponent.md
@@ -7,7 +7,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/InverterNode.md
+++ b/API_DOCS/InverterNode.md
@@ -7,8 +7,13 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `InverterNode() = default;`
-- `~InverterNode() override = default;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `InverterNode` | inverter node 동작을 수행합니다. |
+| `~InverterNode` | inverter node 동작을 수행합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/KeyState.md
+++ b/API_DOCS/KeyState.md
@@ -5,7 +5,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/KeyboardState.md
+++ b/API_DOCS/KeyboardState.md
@@ -5,7 +5,12 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `void Update();`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `Update` | update을(를) 갱신합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/LightComponent.md
+++ b/API_DOCS/LightComponent.md
@@ -7,7 +7,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/LinkData.md
+++ b/API_DOCS/LinkData.md
@@ -5,8 +5,13 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `LinkData() = default;`
-- `~LinkData() = default;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `LinkData` | link data 동작을 수행합니다. |
+| `~LinkData` | link data 동작을 수행합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/MeshColliderComponent.md
+++ b/API_DOCS/MeshColliderComponent.md
@@ -7,7 +7,12 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- `ConvexMeshColliderInfo m_Info;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `m_Info` | m info 상태를 보관합니다. |

--- a/API_DOCS/MeshRenderer.md
+++ b/API_DOCS/MeshRenderer.md
@@ -7,13 +7,20 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `MeshRenderer();`
-- `virtual ~MeshRenderer() override;`
-- `virtual void Awake() override;`
-- `virtual void OnDestroy() override;`
-- `BoundingBox GetBoundingBox() const;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `MeshRenderer` | mesh renderer 동작을 수행합니다. |
+| `~MeshRenderer` | mesh renderer 동작을 수행합니다. |
+| `Awake` | awake 동작을 수행합니다. |
+| `OnDestroy` | on destroy 동작을 수행합니다. |
+| `GetBoundingBox` | bounding box을(를) 가져옵니다. |
 ## Public Properties
-- `LightMapping m_LightMapping;`
-- `bool m_shadowRecive = true;`
-- `bool m_shadowCast = true;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `m_LightMapping` | m light mapping 상태를 보관합니다. |
+| `m_shadowRecive` | m shadow recive 상태를 보관합니다. |
+| `m_shadowCast` | m shadow cast 상태를 보관합니다. |

--- a/API_DOCS/Mode.md
+++ b/API_DOCS/Mode.md
@@ -5,7 +5,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/ModuleBehavior.md
+++ b/API_DOCS/ModuleBehavior.md
@@ -7,7 +7,12 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `ScriptFieldDefault();`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `ScriptFieldDefault` | script field default 동작을 수행합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/MonoBehaviorEvent.md
+++ b/API_DOCS/MonoBehaviorEvent.md
@@ -5,7 +5,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/MonoManager.md
+++ b/API_DOCS/MonoManager.md
@@ -7,26 +7,33 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `void Shutdown();`
-- `std::optional<AssemblyPack> LoadAssembly(const std::string& name, const std::string& path);`
-- `void UnloadAllAssemblies();`
-- `bool ReloadAll(const std::vector<std::pair<std::string, std::string>>& assemblies);`
-- `MonoThread* AttachCurrentThread();`
-- `void        DetachCurrentThread();`
-- `void RegisterInternalCalls();`
-- `MonoClass* GetClass(const char* nameSpace, const char* klassName, MonoImage* image = nullptr) const;`
-- `MonoMethod* GetMethod(MonoClass* klass, const char* methodName, int paramCount) const;`
-- `MonoObject* InvokeStatic(MonoClass* klass, const char* methodName, void** args, int paramCount, MonoObject** outException = nullptr);`
-- `MonoObject* CreateInstance(MonoClass* klass);`
-- `MonoObject* Invoke(MonoObject* instance, const char* methodName, void** args, int paramCount, MonoObject** outException = nullptr);`
-- `MonoString* ToMonoString(const std::string& s) const;`
-- `std::string FromMonoString(MonoString* ms) const;`
-- `static std::string FormatException(MonoObject* exception);`
-- `void GCCollect();`
-- `void GCWaitForPendingFinalizers();`
-- `MonoImage* GetImage(const std::string& assemblyName) const;`
-- `void BindScriptEvents(CSharpScriptComponent* component);`
-- `void UnbindScriptEvents(CSharpScriptComponent* component);`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `Shutdown` | shutdown 동작을 수행합니다. |
+| `LoadAssembly` | assembly을(를) 불러옵니다. |
+| `UnloadAllAssemblies` | unload all assemblies 동작을 수행합니다. |
+| `ReloadAll` | reload all 동작을 수행합니다. |
+| `AttachCurrentThread` | attach current thread 동작을 수행합니다. |
+| `DetachCurrentThread` | detach current thread 동작을 수행합니다. |
+| `RegisterInternalCalls` | register internal calls 동작을 수행합니다. |
+| `GetClass` | class을(를) 가져옵니다. |
+| `GetMethod` | method을(를) 가져옵니다. |
+| `InvokeStatic` | invoke static 동작을 수행합니다. |
+| `CreateInstance` | instance을(를) 생성합니다. |
+| `Invoke` | invoke 동작을 수행합니다. |
+| `ToMonoString` | to mono string 동작을 수행합니다. |
+| `FromMonoString` | from mono string 동작을 수행합니다. |
+| `FormatException` | format exception 동작을 수행합니다. |
+| `GCCollect` | gccollect 동작을 수행합니다. |
+| `GCWaitForPendingFinalizers` | gcwait for pending finalizers 동작을 수행합니다. |
+| `GetImage` | image을(를) 가져옵니다. |
+| `BindScriptEvents` | bind script events 동작을 수행합니다. |
+| `UnbindScriptEvents` | unbind script events 동작을 수행합니다. |
 ## Public Properties
-- `bool enableDebug = false);`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `enableDebug` | debug을(를) 활성화합니다. |

--- a/API_DOCS/MouseState.md
+++ b/API_DOCS/MouseState.md
@@ -5,8 +5,13 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `MouseState() = default;`
-- `void Update();`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `MouseState` | mouse state 동작을 수행합니다. |
+| `Update` | update을(를) 갱신합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/NodeFactory.md
+++ b/API_DOCS/NodeFactory.md
@@ -7,9 +7,16 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `using CreateNodeFunc = std::function<BTNode::NodePtr()>;`
-- `void Register(const std::string& typeName, CreateNodeFunc func);`
-- `BTNode::NodePtr Create(const std::string& typeName);`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `CreateNodeFunc` | node func을(를) 생성합니다. |
+| `Register` | register 동작을 수행합니다. |
+| `Create` | create을(를) 생성합니다. |
 ## Public Properties
-- `std::map<std::string, CreateNodeFunc> m_registry;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `m_registry` | m registry 상태를 보관합니다. |

--- a/API_DOCS/NodeStatus.md
+++ b/API_DOCS/NodeStatus.md
@@ -5,7 +5,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/Object.md
+++ b/API_DOCS/Object.md
@@ -7,12 +7,16 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `Object() = default;`
-- `virtual ~Object() = default;`
-- `virtual void Destroy();`
-- `static void Destroy(Object* objPtr);`
-- `static void SetDontDestroyOnLoad(Object* objPtr);`
-- `static Object* Instantiate(const Object* original, std::string_view newName);`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `Object` | object 동작을 수행합니다. |
+| `~Object` | object 동작을 수행합니다. |
+| `Destroy` | destroy을(를) 파괴합니다. |
+| `SetDontDestroyOnLoad` | dont destroy on load을(를) 설정합니다. |
+| `Instantiate` | instantiate 동작을 수행합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/PadState.md
+++ b/API_DOCS/PadState.md
@@ -5,8 +5,13 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `PadState() = default;`
-- `void Update();`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `PadState` | pad state 동작을 수행합니다. |
+| `Update` | update을(를) 갱신합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/ParallelNode.md
+++ b/API_DOCS/ParallelNode.md
@@ -7,8 +7,13 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `ParallelNode() = default;`
-- `~ParallelNode() override = default;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `ParallelNode` | parallel node 동작을 수행합니다. |
+| `~ParallelNode` | parallel node 동작을 수행합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/ParallelPolicy.md
+++ b/API_DOCS/ParallelPolicy.md
@@ -5,7 +5,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/PhysicsManager.md
+++ b/API_DOCS/PhysicsManager.md
@@ -7,34 +7,40 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `void Initialize();`
-- `void Update(float fixedDeltaTime);`
-- `void Shutdown();`
-- `void ChangeScene();`
-- `[[maybe_unused]] void OnLoadScene();`
-- `void OnUnloadScene();`
-- `void ProcessCallback();`
-- `void RayCast(RayEvent& rayEvent);`
-- `bool Raycast(RayEvent& rayEvent, RaycastHit& hit);`
-- `int Raycast(RayEvent& rayEvent, std::vector<RaycastHit>& hits);`
-- `int BoxSweep(const SweepInput& in, const DirectX::SimpleMath::Vector3& boxExtent, std::vector<HitResult>& out_hits);`
-- `int SphereSweep(const SweepInput& in, float radius, std::vector<HitResult>& out_hits);`
-- `int CapsuleSweep(const SweepInput& in, float radius, float halfHeight, std::vector<HitResult>& out_hits);`
-- `int BoxOverlap(const OverlapInput& in, const DirectX::SimpleMath::Vector3& boxExtent, std::vector<HitResult>& out_hits);`
-- `int SphereOverlap(const OverlapInput& in, float radius, std::vector<HitResult>& out_hits);`
-- `int CapsuleOverlap(const OverlapInput& in, float radius, float halfHeight, std::vector<HitResult>& out_hits);`
-- `void SaveCollisionMatrix();`
-- `void LoadCollisionMatrix();`
-- `void SetRigidBodyState(const RigidBodyState& state);`
-- `bool IsRigidBodyKinematic(unsigned int id) const;`
-- `bool IsRigidBodyTrigger(unsigned int id) const;`
-- `bool IsRigidBodyColliderEnabled(unsigned int id) const;`
-- `bool IsRigidBodyUseGravity(unsigned int id) const;`
-- `void ApplyForcedMoveToCCT(UINT controllerId, const DirectX::SimpleMath::Vector3& initialVelocity);`
-- `void StopForcedMoveOnCCT(UINT controllerId);`
-- `bool IsInForcedMove(UINT controllerId) const;`
-- `void SetControllerPosition(UINT id, const DirectX::SimpleMath::Vector3& pos);`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `Initialize` | initialize 동작을 수행합니다. |
+| `Update` | update을(를) 갱신합니다. |
+| `Shutdown` | shutdown 동작을 수행합니다. |
+| `ChangeScene` | change scene 동작을 수행합니다. |
+| `OnLoadScene` | on load scene 동작을 수행합니다. |
+| `OnUnloadScene` | on unload scene 동작을 수행합니다. |
+| `ProcessCallback` | process callback 동작을 수행합니다. |
+| `RayCast` | ray cast 동작을 수행합니다. |
+| `Raycast` | raycast 동작을 수행합니다. |
+| `BoxSweep` | box sweep 동작을 수행합니다. |
+| `SphereSweep` | sphere sweep 동작을 수행합니다. |
+| `CapsuleSweep` | capsule sweep 동작을 수행합니다. |
+| `BoxOverlap` | box overlap 동작을 수행합니다. |
+| `SphereOverlap` | sphere overlap 동작을 수행합니다. |
+| `CapsuleOverlap` | capsule overlap 동작을 수행합니다. |
+| `SaveCollisionMatrix` | collision matrix을(를) 저장합니다. |
+| `LoadCollisionMatrix` | collision matrix을(를) 불러옵니다. |
+| `SetRigidBodyState` | rigid body state을(를) 설정합니다. |
+| `IsRigidBodyKinematic` | rigid body kinematic 여부를 확인합니다. |
+| `IsRigidBodyTrigger` | rigid body trigger 여부를 확인합니다. |
+| `IsRigidBodyColliderEnabled` | rigid body collider enabled 여부를 확인합니다. |
+| `IsRigidBodyUseGravity` | rigid body use gravity 여부를 확인합니다. |
+| `ApplyForcedMoveToCCT` | forced move to cct을(를) 적용합니다. |
+| `StopForcedMoveOnCCT` | stop forced move on cct 동작을 수행합니다. |
+| `IsInForcedMove` | in forced move 여부를 확인합니다. |
+| `SetControllerPosition` | controller position을(를) 설정합니다. |
 ## Public Properties
-- `friend class Scene;`
-- `using ColliderID = unsigned int;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `Scene` | scene 상태를 보관합니다. |
+| `ColliderID` | collider id 상태를 보관합니다. |

--- a/API_DOCS/PlayerInputComponent.md
+++ b/API_DOCS/PlayerInputComponent.md
@@ -7,13 +7,18 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `void Update(float tick) override;`
-- `void SetActionMap(std::string mapName);`
-- `void SetActionMap(ActionMap* _actionMap);`
-- `void SetControllerVibration(float tick, float leftMotorSpeed, float rightMotorSpeed, float lowFre, float highFre);`
-- `void SetControllerVibration(float tick, float power);`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `Update` | update을(를) 갱신합니다. |
+| `SetActionMap` | action map을(를) 설정합니다. |
+| `SetControllerVibration` | controller vibration을(를) 설정합니다. |
 ## Public Properties
-- `ActionMap* m_actionMap = nullptr;`
-- `std::string m_actionMapName = "None";`
-- `int controllerIndex = 0;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `m_actionMap` | m action map 상태를 보관합니다. |
+| `m_actionMapName` | m action map name 상태를 보관합니다. |
+| `controllerIndex` | controller index 상태를 보관합니다. |

--- a/API_DOCS/Prefab.md
+++ b/API_DOCS/Prefab.md
@@ -7,12 +7,15 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `Prefab() = default;`
-- `Prefab(std::string_view name, const GameObject* source);`
-- `~Prefab() override = default;`
-- `static Prefab* CreateFromGameObject(const GameObject* source, std::string_view name = "");`
-- `GameObject* Instantiate(std::string_view newName = "") const;`
-- `GameObject* Instantiate(Scene* targetScene, std::string_view newName = "") const;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `Prefab` | prefab 동작을 수행합니다. |
+| `~Prefab` | prefab 동작을 수행합니다. |
+| `CreateFromGameObject` | from game object을(를) 생성합니다. |
+| `Instantiate` | instantiate 동작을 수행합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/PrefabEditor.md
+++ b/API_DOCS/PrefabEditor.md
@@ -7,8 +7,13 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `void Open(const std::string& path);`
-- `void Close(bool apply = true);`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `Open` | open 동작을 수행합니다. |
+| `Close` | close 동작을 수행합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/PrefabUtility.md
+++ b/API_DOCS/PrefabUtility.md
@@ -7,18 +7,24 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `Prefab* CreatePrefab(const GameObject* source, std::string_view name = "");`
-- `GameObject* InstantiatePrefab(const Prefab* prefab, std::string_view name = "");`
-- `GameObject* InstantiatePrefab(const Prefab* prefab, Scene* targetScene, std::string_view name = "");`
-- `void RegisterInstance(GameObject* instance, const Prefab* prefab);`
-- `void UpdateInstances(const Prefab* prefab);`
-- `bool SavePrefab(const Prefab* prefab, const std::string& path);`
-- `Prefab* LoadPrefabFullPath(const std::string& path);`
-- `Prefab* LoadPrefab(const std::string& path);`
-- `Prefab* LoadPrefabGuid(const FileGuid& guid);`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `CreatePrefab` | prefab을(를) 생성합니다. |
+| `InstantiatePrefab` | instantiate prefab 동작을 수행합니다. |
+| `RegisterInstance` | register instance 동작을 수행합니다. |
+| `UpdateInstances` | instances을(를) 갱신합니다. |
+| `SavePrefab` | prefab을(를) 저장합니다. |
+| `LoadPrefabFullPath` | prefab full path을(를) 불러옵니다. |
+| `LoadPrefab` | prefab을(를) 불러옵니다. |
+| `LoadPrefabGuid` | prefab guid을(를) 불러옵니다. |
 ## Public Properties
-- `Core::Delegate<void, GameObject&> prefabInstanceUpdated;`
-- `Core::Delegate<void, GameObject&> prefabInstanceApplied;`
-- `Core::Delegate<void, GameObject&> prefabInstanceReverted;`
-- `Core::Delegate<void, GameObject&> prefabInstanceUnpacked;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `prefabInstanceUpdated` | prefab instance updated 상태를 보관합니다. |
+| `prefabInstanceApplied` | prefab instance applied 상태를 보관합니다. |
+| `prefabInstanceReverted` | prefab instance reverted 상태를 보관합니다. |
+| `prefabInstanceUnpacked` | prefab instance unpacked 상태를 보관합니다. |

--- a/API_DOCS/RagdollComponent.md
+++ b/API_DOCS/RagdollComponent.md
@@ -7,7 +7,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/RectTransformComponent.md
+++ b/API_DOCS/RectTransformComponent.md
@@ -7,17 +7,24 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `RectTransformComponent();`
-- `virtual ~RectTransformComponent() = default;`
-- `void UpdateLayout(const Mathf::Rect& parentRect);`
-- `void SetAnchorMin(const Mathf::Vector2& anchorMin);`
-- `void SetAnchorMax(const Mathf::Vector2& anchorMax);`
-- `Mathf::Vector2 GetAnchoredPosition() const;`
-- `void SetAnchoredPosition(const Mathf::Vector2& position);`
-- `void SetSizeDelta(const Mathf::Vector2& size);`
-- `void SetPivot(const Mathf::Vector2& pivot);`
-- `void SetAnchorPreset(AnchorPreset preset);`
-- `void SetParentKeepWorldPosition(GameObject* newParent);`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `RectTransformComponent` | rect transform component 동작을 수행합니다. |
+| `~RectTransformComponent` | rect transform component 동작을 수행합니다. |
+| `UpdateLayout` | layout을(를) 갱신합니다. |
+| `SetAnchorMin` | anchor min을(를) 설정합니다. |
+| `SetAnchorMax` | anchor max을(를) 설정합니다. |
+| `GetAnchoredPosition` | anchored position을(를) 가져옵니다. |
+| `SetAnchoredPosition` | anchored position을(를) 설정합니다. |
+| `SetSizeDelta` | size delta을(를) 설정합니다. |
+| `SetPivot` | pivot을(를) 설정합니다. |
+| `SetAnchorPreset` | anchor preset을(를) 설정합니다. |
+| `SetParentKeepWorldPosition` | parent keep world position을(를) 설정합니다. |
 ## Public Properties
-- `const Mathf::Rect& newParentRect);`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `newParentRect` | new parent rect 상태를 보관합니다. |

--- a/API_DOCS/RegistableEvent.md
+++ b/API_DOCS/RegistableEvent.md
@@ -7,7 +7,12 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `void RegisterOverriddenEvents(Scene* scene) final override;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `RegisterOverriddenEvents` | register overridden events 동작을 수행합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/RigidBodyComponent.md
+++ b/API_DOCS/RigidBodyComponent.md
@@ -7,18 +7,23 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `void Awake() override;`
-- `void OnDestroy() override;`
-- `void SetBodyType(const EBodyType& bodyType);`
-- `void SetAngularDamping(float _AngularDamping = 0.05f);`
-- `void SetLinearDamping(float _LinearDamping);`
-- `void AddForce(const Mathf::Vector3& force, EForceMode forceMode = EForceMode::FORCE);`
-- `void SetMass(float _mass);`
-- `void SetKinematic(bool isKinematic);`
-- `void SetIsTrigger(bool isTrigger);`
-- `void SetColliderEnabled(bool enabled);`
-- `void UseGravity(bool useGravity);`
-- `void NotifyPhysicsStateChange(const Mathf::Vector3& position);`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `Awake` | awake 동작을 수행합니다. |
+| `OnDestroy` | on destroy 동작을 수행합니다. |
+| `SetBodyType` | body type을(를) 설정합니다. |
+| `SetAngularDamping` | angular damping을(를) 설정합니다. |
+| `SetLinearDamping` | linear damping을(를) 설정합니다. |
+| `AddForce` | force을(를) 추가합니다. |
+| `SetMass` | mass을(를) 설정합니다. |
+| `SetKinematic` | kinematic을(를) 설정합니다. |
+| `SetIsTrigger` | is trigger을(를) 설정합니다. |
+| `SetColliderEnabled` | collider enabled을(를) 설정합니다. |
+| `UseGravity` | use gravity 동작을 수행합니다. |
+| `NotifyPhysicsStateChange` | notify physics state change 동작을 수행합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/Rolloff.md
+++ b/API_DOCS/Rolloff.md
@@ -5,7 +5,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/Scene.md
+++ b/API_DOCS/Scene.md
@@ -5,85 +5,80 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `Scene();`
-- `~Scene();`
-- `std::shared_ptr<GameObject> AddGameObject(const std::shared_ptr<GameObject>& sceneObject);`
-- `std::shared_ptr<GameObject> CreateGameObject(std::string_view name, GameObjectType type = GameObjectType::Empty, GameObject::Index parentIndex = -1);`
-- `std::shared_ptr<GameObject> LoadGameObject(size_t instanceID, std::string_view name, GameObjectType type = GameObjectType::Empty, GameObject::Index parentIndex = -1);`
-- `std::shared_ptr<GameObject> GetGameObject(GameObject::Index index);`
-- `std::shared_ptr<GameObject> TryGetGameObject(GameObject::Index index);`
-- `void DetachGameObjectHierarchy(GameObject* root);`
-- `GameObject::Index AttachExistingGameObject(std::shared_ptr<GameObject> go, GameObject::Index parentIndex);`
-- `AttachExistingGameObjectHierarchy(const std::vector<std::shared_ptr<GameObject>>& roots);`
-- `std::shared_ptr<GameObject> GetGameObject(std::string_view name);`
-- `void AddSelectedSceneObject(GameObject* sceneObject);`
-- `void RemoveSelectedSceneObject(GameObject* sceneObject);`
-- `void ClearSelectedSceneObjects();`
-- `void AddRootGameObject(std::string_view name);`
-- `void DestroyGameObject(const std::shared_ptr<GameObject>& sceneObject);`
-- `void DestroyGameObject(GameObject::Index index);`
-- `void CullMeshData();`
-- `void InternalPauseUpdateForUI();`
-- `std::vector<std::shared_ptr<GameObject>> CreateGameObjects(size_t createSize, GameObject::Index parentIndex = -1);`
-- `void Awake();`
-- `void OnEnable();`
-- `void Start();`
-- `void FixedUpdate(float deltaSecond);`
-- `void OnTriggerEnter(const Collision& collider);`
-- `void OnTriggerStay(const Collision& collider);`
-- `void OnTriggerExit(const Collision& collider);`
-- `void OnCollisionEnter(const Collision& collider);`
-- `void OnCollisionStay(const Collision& collider);`
-- `void OnCollisionExit(const Collision& collider);`
-- `void Update(float deltaSecond);`
-- `void YieldNull();`
-- `void LateUpdate(float deltaSecond);`
-- `void OnDisable();`
-- `void OnDestroy();`
-- `void AllDestroyMark();`
-- `void ResetSelectedSceneObject();`
-- `void CollectLightComponent(LightComponent* ptr);`
-- `void UnCollectLightComponent(LightComponent* ptr);`
-- `uint32 UpdateLight(LightProperties& lightProperties) const;`
-- `std::pair<size_t, Light&> AddLight();`
-- `Light& GetLight(size_t index);`
-- `void RemoveLight(size_t index);`
-- `void DestroyLight();`
-- `void CollectMeshRenderer(MeshRenderer* ptr);`
-- `void UnCollectMeshRenderer(MeshRenderer* ptr);`
-- `void CollectSpriteRenderer(SpriteRenderer* ptr);`
-- `void UnCollectSpriteRenderer(SpriteRenderer* ptr);`
-- `void CollectTerrainComponent(TerrainComponent* ptr);`
-- `void UnCollectTerrainComponent(TerrainComponent* ptr);`
-- `void CollectFoliageComponent(FoliageComponent* ptr);`
-- `void UnCollectFoliageComponent(FoliageComponent* ptr);`
-- `void CollectDecalComponent(DecalComponent* ptr);`
-- `void UnCollectDecalComponent(DecalComponent* ptr);`
-- `void CollectRigidBodyComponent(RigidBodyComponent* ptr);`
-- `void UnCollectRigidBodyComponent(RigidBodyComponent* ptr);`
-- `void CollectColliderComponent(BoxColliderComponent* ptr);`
-- `void CollectColliderComponent(SphereColliderComponent* ptr);`
-- `void CollectColliderComponent(CapsuleColliderComponent* ptr);`
-- `void CollectColliderComponent(MeshColliderComponent* ptr);`
-- `void CollectColliderComponent(CharacterControllerComponent* ptr);`
-- `void CollectColliderComponent(TerrainColliderComponent* ptr);`
-- `void UnCollectColliderComponent(BoxColliderComponent* ptr);`
-- `void UnCollectColliderComponent(SphereColliderComponent* ptr);`
-- `void UnCollectColliderComponent(CapsuleColliderComponent* ptr);`
-- `void UnCollectColliderComponent(MeshColliderComponent* ptr);`
-- `void UnCollectColliderComponent(CharacterControllerComponent* ptr);`
-- `void UnCollectColliderComponent(TerrainColliderComponent* ptr);`
-- `void AddCanvas(const std::shared_ptr<GameObject>& canvas);`
-- `void RemoveCanvas(const std::shared_ptr<GameObject>& canvas);`
-- `std::shared_ptr<GameObject> FindCanvasName(std::string_view name);`
-- `std::shared_ptr<GameObject> FindCanvasIndex(size_t index);`
-- `void AllUpdateWorldMatrix();`
-- `void AllUIUpdateWorldMatrix();`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `Scene` | scene 동작을 수행합니다. |
+| `~Scene` | scene 동작을 수행합니다. |
+| `AddGameObject` | game object을(를) 추가합니다. |
+| `CreateGameObject` | game object을(를) 생성합니다. |
+| `LoadGameObject` | game object을(를) 불러옵니다. |
+| `GetGameObject` | game object을(를) 가져옵니다. |
+| `TryGetGameObject` | try get game object 동작을 수행합니다. |
+| `DetachGameObjectHierarchy` | detach game object hierarchy 동작을 수행합니다. |
+| `AttachExistingGameObject` | attach existing game object 동작을 수행합니다. |
+| `AttachExistingGameObjectHierarchy` | attach existing game object hierarchy 동작을 수행합니다. |
+| `AddSelectedSceneObject` | selected scene object을(를) 추가합니다. |
+| `RemoveSelectedSceneObject` | selected scene object을(를) 제거합니다. |
+| `ClearSelectedSceneObjects` | selected scene objects을(를) 비웁니다. |
+| `AddRootGameObject` | root game object을(를) 추가합니다. |
+| `DestroyGameObject` | game object을(를) 파괴합니다. |
+| `CullMeshData` | cull mesh data 동작을 수행합니다. |
+| `InternalPauseUpdateForUI` | internal pause update for ui 동작을 수행합니다. |
+| `CreateGameObjects` | game objects을(를) 생성합니다. |
+| `Awake` | awake 동작을 수행합니다. |
+| `OnEnable` | on enable 동작을 수행합니다. |
+| `Start` | start 동작을 수행합니다. |
+| `FixedUpdate` | fixed update 동작을 수행합니다. |
+| `OnTriggerEnter` | on trigger enter 동작을 수행합니다. |
+| `OnTriggerStay` | on trigger stay 동작을 수행합니다. |
+| `OnTriggerExit` | on trigger exit 동작을 수행합니다. |
+| `OnCollisionEnter` | on collision enter 동작을 수행합니다. |
+| `OnCollisionStay` | on collision stay 동작을 수행합니다. |
+| `OnCollisionExit` | on collision exit 동작을 수행합니다. |
+| `Update` | update을(를) 갱신합니다. |
+| `YieldNull` | yield null 동작을 수행합니다. |
+| `LateUpdate` | late update 동작을 수행합니다. |
+| `OnDisable` | on disable 동작을 수행합니다. |
+| `OnDestroy` | on destroy 동작을 수행합니다. |
+| `AllDestroyMark` | all destroy mark 동작을 수행합니다. |
+| `ResetSelectedSceneObject` | reset selected scene object 동작을 수행합니다. |
+| `CollectLightComponent` | collect light component 동작을 수행합니다. |
+| `UnCollectLightComponent` | un collect light component 동작을 수행합니다. |
+| `UpdateLight` | light을(를) 갱신합니다. |
+| `AddLight` | light을(를) 추가합니다. |
+| `GetLight` | light을(를) 가져옵니다. |
+| `RemoveLight` | light을(를) 제거합니다. |
+| `DestroyLight` | light을(를) 파괴합니다. |
+| `CollectMeshRenderer` | collect mesh renderer 동작을 수행합니다. |
+| `UnCollectMeshRenderer` | un collect mesh renderer 동작을 수행합니다. |
+| `CollectSpriteRenderer` | collect sprite renderer 동작을 수행합니다. |
+| `UnCollectSpriteRenderer` | un collect sprite renderer 동작을 수행합니다. |
+| `CollectTerrainComponent` | collect terrain component 동작을 수행합니다. |
+| `UnCollectTerrainComponent` | un collect terrain component 동작을 수행합니다. |
+| `CollectFoliageComponent` | collect foliage component 동작을 수행합니다. |
+| `UnCollectFoliageComponent` | un collect foliage component 동작을 수행합니다. |
+| `CollectDecalComponent` | collect decal component 동작을 수행합니다. |
+| `UnCollectDecalComponent` | un collect decal component 동작을 수행합니다. |
+| `CollectRigidBodyComponent` | collect rigid body component 동작을 수행합니다. |
+| `UnCollectRigidBodyComponent` | un collect rigid body component 동작을 수행합니다. |
+| `CollectColliderComponent` | collect collider component 동작을 수행합니다. |
+| `UnCollectColliderComponent` | un collect collider component 동작을 수행합니다. |
+| `AddCanvas` | canvas을(를) 추가합니다. |
+| `RemoveCanvas` | canvas을(를) 제거합니다. |
+| `FindCanvasName` | canvas name을(를) 탐색합니다. |
+| `FindCanvasIndex` | canvas index을(를) 탐색합니다. |
+| `AllUpdateWorldMatrix` | all update world matrix 동작을 수행합니다. |
+| `AllUIUpdateWorldMatrix` | all uiupdate world matrix 동작을 수행합니다. |
 ## Public Properties
-- `std::vector<std::shared_ptr<GameObject>> m_SceneObjects;`
-- `std::future<void> m_AIFuture;`
-- `HashingString m_sceneName;`
-- `GameObject*					m_selectedSceneObject = nullptr;`
-- `std::vector<GameObject*>	m_selectedSceneObjects;`
-- `std::vector<std::shared_ptr<MeshRenderer>> m_visibleMeshesScratch;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `m_SceneObjects` | m scene objects 상태를 보관합니다. |
+| `m_AIFuture` | m aifuture 상태를 보관합니다. |
+| `m_sceneName` | m scene name 상태를 보관합니다. |
+| `m_selectedSceneObject` | m selected scene object 상태를 보관합니다. |
+| `m_selectedSceneObjects` | m selected scene objects 상태를 보관합니다. |
+| `m_visibleMeshesScratch` | m visible meshes scratch 상태를 보관합니다. |

--- a/API_DOCS/SceneManager.md
+++ b/API_DOCS/SceneManager.md
@@ -7,39 +7,46 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `void ManagerInitialize();`
-- `void Editor();`
-- `void Initialization();`
-- `void Physics(float deltaSecond);`
-- `void InputEvents(float deltaSecond);`
-- `void GameLogic(float deltaSecond = 0);`
-- `void SceneRendering(float deltaSecond);`
-- `void OnDrawGizmos();`
-- `void GUIRendering();`
-- `void EndOfFrame();`
-- `void Pausing();`
-- `void DisableOrEnable();`
-- `void Decommissioning();`
-- `void SetDecommissioning();`
-- `Scene* CreateScene(std::string_view name = "SampleScene");`
-- `Scene* SaveScene(std::string_view name = "SampleScene");`
-- `Scene* LoadSceneImmediate(std::string_view name = "SampleScene");`
-- `Scene* LoadScene(std::string_view name = "SampleScene");`
-- `void SaveSceneAsync(std::string_view name = "SampleScene");`
-- `std::future<Scene*> LoadSceneAsync(std::string_view name = "SampleScene");`
-- `void LoadSceneAsyncAndWaitCallback(std::string_view name = "SampleScene");`
-- `void ActivateScene(Scene* sceneToActivate, bool isOldSceneDelete = true);`
-- `void BeforeAwakeSceneLoad();`
-- `bool IsSceneLoading() const;`
-- `void WaitForSceneLoad();`
-- `void AddDontDestroyOnLoad(std::shared_ptr<Object> objPtr);`
-- `void RemoveDontDestroyOnLoad(std::shared_ptr<Object> objPtr);`
-- `void RebindEventDontDestroyOnLoadObjects(Scene* scene);`
-- `void SetGameStart(bool isStart);`
-- `void SetGamePaused(bool isPaused);`
-- `void ToggleGamePaused();`
-- `std::vector<MeshRenderer*> GetAllMeshRenderers() const;`
-- `void VolumeProfileApply();`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `ManagerInitialize` | manager initialize 동작을 수행합니다. |
+| `Editor` | editor 동작을 수행합니다. |
+| `Initialization` | initialization 동작을 수행합니다. |
+| `Physics` | physics 동작을 수행합니다. |
+| `InputEvents` | input events 동작을 수행합니다. |
+| `GameLogic` | game logic 동작을 수행합니다. |
+| `SceneRendering` | scene rendering 동작을 수행합니다. |
+| `OnDrawGizmos` | on draw gizmos 동작을 수행합니다. |
+| `GUIRendering` | guirendering 동작을 수행합니다. |
+| `EndOfFrame` | end of frame 동작을 수행합니다. |
+| `Pausing` | pausing 동작을 수행합니다. |
+| `DisableOrEnable` | or enable을(를) 비활성화합니다. |
+| `Decommissioning` | decommissioning 동작을 수행합니다. |
+| `SetDecommissioning` | decommissioning을(를) 설정합니다. |
+| `CreateScene` | scene을(를) 생성합니다. |
+| `SaveScene` | scene을(를) 저장합니다. |
+| `LoadSceneImmediate` | scene immediate을(를) 불러옵니다. |
+| `LoadScene` | scene을(를) 불러옵니다. |
+| `SaveSceneAsync` | scene async을(를) 저장합니다. |
+| `LoadSceneAsync` | scene async을(를) 불러옵니다. |
+| `LoadSceneAsyncAndWaitCallback` | scene async and wait callback을(를) 불러옵니다. |
+| `ActivateScene` | activate scene 동작을 수행합니다. |
+| `BeforeAwakeSceneLoad` | before awake scene load 동작을 수행합니다. |
+| `IsSceneLoading` | scene loading 여부를 확인합니다. |
+| `WaitForSceneLoad` | wait for scene load 동작을 수행합니다. |
+| `AddDontDestroyOnLoad` | dont destroy on load을(를) 추가합니다. |
+| `RemoveDontDestroyOnLoad` | dont destroy on load을(를) 제거합니다. |
+| `RebindEventDontDestroyOnLoadObjects` | rebind event dont destroy on load objects 동작을 수행합니다. |
+| `SetGameStart` | game start을(를) 설정합니다. |
+| `SetGamePaused` | game paused을(를) 설정합니다. |
+| `ToggleGamePaused` | toggle game paused 동작을 수행합니다. |
+| `GetAllMeshRenderers` | all mesh renderers을(를) 가져옵니다. |
+| `VolumeProfileApply` | volume profile apply 동작을 수행합니다. |
 ## Public Properties
-- `std::future<Scene*>                 m_loadingSceneFuture;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `m_loadingSceneFuture` | m loading scene future 상태를 보관합니다. |

--- a/API_DOCS/SelectorNode.md
+++ b/API_DOCS/SelectorNode.md
@@ -7,8 +7,13 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `SelectorNode() = default;`
-- `~SelectorNode() override = default;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `SelectorNode` | selector node 동작을 수행합니다. |
+| `~SelectorNode` | selector node 동작을 수행합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/SequenceNode.md
+++ b/API_DOCS/SequenceNode.md
@@ -7,8 +7,13 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `SequenceNode() = default;`
-- `~SequenceNode() override = default;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `SequenceNode` | sequence node 동작을 수행합니다. |
+| `~SequenceNode` | sequence node 동작을 수행합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/SoundComponent.md
+++ b/API_DOCS/SoundComponent.md
@@ -7,31 +7,38 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `void Start() override;`
-- `void Update(float tick) override;`
-- `void LateUpdate(float tick) override;`
-- `void OnDestroy() override;`
-- `void Play();`
-- `void Stop();`
-- `void Pause(bool pause);`
-- `bool IsPlaying();`
-- `void PlayOneShot();`
-- `void EditorSet();`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `Start` | start 동작을 수행합니다. |
+| `Update` | update을(를) 갱신합니다. |
+| `LateUpdate` | late update 동작을 수행합니다. |
+| `OnDestroy` | on destroy 동작을 수행합니다. |
+| `Play` | play 동작을 수행합니다. |
+| `Stop` | stop 동작을 수행합니다. |
+| `Pause` | pause 동작을 수행합니다. |
+| `IsPlaying` | playing 여부를 확인합니다. |
+| `PlayOneShot` | play one shot 동작을 수행합니다. |
+| `EditorSet` | editor set 동작을 수행합니다. |
 ## Public Properties
-- `std::string clipKey;`
-- `ChannelType bus = ChannelType::SFX;`
-- `float volume = 1.f;`
-- `float pitch = 1.f;`
-- `int priority = 128;`
-- `float spatialBlend = 1.0f;`
-- `float minDistance = 1.0f;`
-- `float maxDistance = 50.0f;`
-- `float  reverbLevel = 0.0f;`
-- `int    reverbIndex = 0;`
-- `Rolloff rolloff = Rolloff::Inverse;`
-- `std::vector<CurvePoint> localRolloffCurve;`
-- `bool loop = false;`
-- `bool playOnStart = false;`
-- `bool spatial = false;`
-- `bool useReverbSend = false;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `clipKey` | clip key 상태를 보관합니다. |
+| `bus` | bus 상태를 보관합니다. |
+| `volume` | volume 상태를 보관합니다. |
+| `pitch` | pitch 상태를 보관합니다. |
+| `priority` | priority 상태를 보관합니다. |
+| `spatialBlend` | spatial blend 상태를 보관합니다. |
+| `minDistance` | min distance 상태를 보관합니다. |
+| `maxDistance` | max distance 상태를 보관합니다. |
+| `reverbLevel` | reverb level 상태를 보관합니다. |
+| `reverbIndex` | reverb index 상태를 보관합니다. |
+| `rolloff` | rolloff 상태를 보관합니다. |
+| `localRolloffCurve` | local rolloff curve 상태를 보관합니다. |
+| `loop` | loop 상태를 보관합니다. |
+| `playOnStart` | play on start 상태를 보관합니다. |
+| `spatial` | spatial 상태를 보관합니다. |
+| `useReverbSend` | use reverb send 상태를 보관합니다. |

--- a/API_DOCS/SoundManager.md
+++ b/API_DOCS/SoundManager.md
@@ -7,29 +7,34 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `bool initialize(int maxChannels);`
-- `void update();`
-- `void shutdown();`
-- `void Initialize();`
-- `void SoundLoaderThread();`
-- `void LoadSounds();`
-- `void setMasterVolume(float volume);`
-- `void setBusVolume(ChannelType bus, float linear);`
-- `void setBusVolumeDb(ChannelType bus, float db);`
-- `void setBusVolumePercent(ChannelType bus, int percent);`
-- `void unloadSound(const std::string& name);`
-- `std::vector<std::string> getAllClipKeys() const;`
-- `void setGroupMaxVoices(ChannelType bus, int maxVoices);`
-- `void setGroupStealPolicy(ChannelType bus, StealPolicy p);`
-- `void setGroupPreemptSameClip(ChannelType bus, bool on);`
-- `void configureVoicePool(const std::string& clipKey, ChannelType bus, int capacity);`
-- `void clearVoicePool(const std::string& clipKey, ChannelType bus);`
-- `void stopByOwnerTag(void* ownerTag);`
-- `void stopByOwnerTag(void* ownerTag, ChannelType bus);`
-- `bool getListenerPosition(FMOD_VECTOR& out) const;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `initialize` | initialize 동작을 수행합니다. |
+| `update` | update을(를) 갱신합니다. |
+| `shutdown` | shutdown 동작을 수행합니다. |
+| `Initialize` | initialize 동작을 수행합니다. |
+| `SoundLoaderThread` | sound loader thread 동작을 수행합니다. |
+| `LoadSounds` | sounds을(를) 불러옵니다. |
+| `setMasterVolume` | master volume을(를) 설정합니다. |
+| `setBusVolume` | bus volume을(를) 설정합니다. |
+| `setBusVolumeDb` | bus volume db을(를) 설정합니다. |
+| `setBusVolumePercent` | bus volume percent을(를) 설정합니다. |
+| `unloadSound` | unload sound 동작을 수행합니다. |
+| `getAllClipKeys` | all clip keys을(를) 가져옵니다. |
+| `setGroupMaxVoices` | group max voices을(를) 설정합니다. |
+| `setGroupStealPolicy` | group steal policy을(를) 설정합니다. |
+| `setGroupPreemptSameClip` | group preempt same clip을(를) 설정합니다. |
+| `configureVoicePool` | configure voice pool 동작을 수행합니다. |
+| `clearVoicePool` | voice pool을(를) 비웁니다. |
+| `stopByOwnerTag` | stop by owner tag 동작을 수행합니다. |
+| `getListenerPosition` | listener position을(를) 가져옵니다. |
 ## Public Properties
-- `const FMOD_VECTOR& up);`
-- `bool is3D = false, bool loop = false);`
-- `void* ownerTag = nullptr);`
-- `void* ownerTag = nullptr);`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `up` | up 상태를 보관합니다. |
+| `is3D` | 3 d 여부를 확인합니다. |
+| `ownerTag` | owner tag 상태를 보관합니다. |

--- a/API_DOCS/SphereColliderComponent.md
+++ b/API_DOCS/SphereColliderComponent.md
@@ -7,11 +7,16 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- `float radius = 1.0f;`
-- `float staticFriction = 0.5f;`
-- `float dynamicFriction = 0.4f;`
-- `float restitution = 0.3f;`
-- `float density = 10.0f;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `radius` | radius 상태를 보관합니다. |
+| `staticFriction` | static friction 상태를 보관합니다. |
+| `dynamicFriction` | dynamic friction 상태를 보관합니다. |
+| `restitution` | restitution 상태를 보관합니다. |
+| `density` | density 상태를 보관합니다. |

--- a/API_DOCS/SpriteRenderer.md
+++ b/API_DOCS/SpriteRenderer.md
@@ -7,9 +7,14 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `virtual void Awake() override;`
-- `virtual void OnDestroy() override;`
-- `void SetSprite(const std::shared_ptr<Texture>& ptr);`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `Awake` | awake 동작을 수행합니다. |
+| `OnDestroy` | on destroy 동작을 수행합니다. |
+| `SetSprite` | sprite을(를) 설정합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/SpriteSheetComponent.md
+++ b/API_DOCS/SpriteSheetComponent.md
@@ -7,10 +7,15 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `void LoadSpriteSheet(const file::path& path);`
-- `virtual void Awake() override;`
-- `virtual void Update(float tick) override;`
-- `virtual void OnDestroy() override;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `LoadSpriteSheet` | sprite sheet을(를) 불러옵니다. |
+| `Awake` | awake 동작을 수행합니다. |
+| `Update` | update을(를) 갱신합니다. |
+| `OnDestroy` | on destroy 동작을 수행합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/StateMachineComponent.md
+++ b/API_DOCS/StateMachineComponent.md
@@ -7,14 +7,21 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `using ConditionFunc = std::function<bool(const BlackBoard&)>;`
-- `virtual ~StateMachineComponent() = default;`
-- `void Initialize() override;`
-- `FSM::FSMState* AddState(const std::string& name);`
-- `void RemoveState(FSM::FSMState* state);`
-- `FSM::Transition* AddTransition(FSM::FSMState* from, FSM::FSMState* to, ConditionFunc condition);`
-- `void RemoveTransition(FSM::Transition* transition);`
-- `FSM::FSMState* FindStateByName(const std::string& name) const;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `ConditionFunc` | condition func 동작을 수행합니다. |
+| `~StateMachineComponent` | state machine component 동작을 수행합니다. |
+| `Initialize` | initialize 동작을 수행합니다. |
+| `AddState` | state을(를) 추가합니다. |
+| `RemoveState` | state을(를) 제거합니다. |
+| `AddTransition` | transition을(를) 추가합니다. |
+| `RemoveTransition` | transition을(를) 제거합니다. |
+| `FindStateByName` | state by name을(를) 탐색합니다. |
 ## Public Properties
-- `std::string name;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `name` | name 상태를 보관합니다. |

--- a/API_DOCS/StaticGameObjectType.md
+++ b/API_DOCS/StaticGameObjectType.md
@@ -7,7 +7,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/StealPolicy.md
+++ b/API_DOCS/StealPolicy.md
@@ -5,7 +5,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/TagManager.md
+++ b/API_DOCS/TagManager.md
@@ -7,20 +7,25 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `void Initialize();`
-- `void Finalize();`
-- `void Load();`
-- `void Save();`
-- `void AddTag(std::string_view tag);`
-- `void RemoveTag(std::string_view tag);`
-- `bool HasTag(std::string_view tag) const;`
-- `void AddLayer(std::string_view layer);`
-- `void RemoveLayer(std::string_view layer);`
-- `bool HasLayer(std::string_view layer) const;`
-- `void AddTagToObject(std::string_view tag, GameObject* object);`
-- `void RemoveTagFromObject(std::string_view tag, GameObject* object);`
-- `void AddObjectToLayer(std::string_view layer, GameObject* object);`
-- `void RemoveObjectFromLayer(std::string_view layer, GameObject* object);`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `Initialize` | initialize 동작을 수행합니다. |
+| `Finalize` | finalize 동작을 수행합니다. |
+| `Load` | load을(를) 불러옵니다. |
+| `Save` | save을(를) 저장합니다. |
+| `AddTag` | tag을(를) 추가합니다. |
+| `RemoveTag` | tag을(를) 제거합니다. |
+| `HasTag` | has tag 동작을 수행합니다. |
+| `AddLayer` | layer을(를) 추가합니다. |
+| `RemoveLayer` | layer을(를) 제거합니다. |
+| `HasLayer` | has layer 동작을 수행합니다. |
+| `AddTagToObject` | tag to object을(를) 추가합니다. |
+| `RemoveTagFromObject` | tag from object을(를) 제거합니다. |
+| `AddObjectToLayer` | object to layer을(를) 추가합니다. |
+| `RemoveObjectFromLayer` | object from layer을(를) 제거합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/TerrainColliderComponent.md
+++ b/API_DOCS/TerrainColliderComponent.md
@@ -7,7 +7,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/TerrainComponent.md
+++ b/API_DOCS/TerrainComponent.md
@@ -7,26 +7,31 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `TerrainComponent();`
-- `virtual ~TerrainComponent() = default;`
-- `void Initialize();`
-- `void Resize(int newWidth, int newHeight);`
-- `virtual void Awake() override;`
-- `virtual void OnDestroy() override;`
-- `void Save(const std::wstring& assetRoot, const std::wstring& name);`
-- `bool Load(const std::wstring& filePath);`
-- `void BuildOutTrrain(const std::wstring& buildPath, const std::wstring& terrainName);`
-- `bool LoadRunTimeTerrain(const std::wstring& filePath);`
-- `void ApplyBrush(const TerrainBrush& brush);`
-- `void RecalculateNormalsPatch(int minX, int minY, int maxX, int maxY);`
-- `void PaintLayer(uint32_t layerId, int x, int y, float strength);`
-- `void UpdateLayerDesc();`
-- `void AddLayer(const std::wstring& path, const std::wstring& diffuseFile, float tilling);`
-- `void RemoveLayer(uint32_t layerID);`
-- `void ClearLayers();`
-- `void RefreshTexture();`
-- `bool LoadBrushMaskTexture(const std::wstring& path, std::vector<uint8_t>& outMask, int& dataWidth, int& dataHeight);`
-- `void SetBrushMaskTexture(TerrainBrush* brush, const std::wstring& path);`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `TerrainComponent` | terrain component 동작을 수행합니다. |
+| `~TerrainComponent` | terrain component 동작을 수행합니다. |
+| `Initialize` | initialize 동작을 수행합니다. |
+| `Resize` | resize 동작을 수행합니다. |
+| `Awake` | awake 동작을 수행합니다. |
+| `OnDestroy` | on destroy 동작을 수행합니다. |
+| `Save` | save을(를) 저장합니다. |
+| `Load` | load을(를) 불러옵니다. |
+| `BuildOutTrrain` | build out trrain 동작을 수행합니다. |
+| `LoadRunTimeTerrain` | run time terrain을(를) 불러옵니다. |
+| `ApplyBrush` | brush을(를) 적용합니다. |
+| `RecalculateNormalsPatch` | recalculate normals patch 동작을 수행합니다. |
+| `PaintLayer` | paint layer 동작을 수행합니다. |
+| `UpdateLayerDesc` | layer desc을(를) 갱신합니다. |
+| `AddLayer` | layer을(를) 추가합니다. |
+| `RemoveLayer` | layer을(를) 제거합니다. |
+| `ClearLayers` | layers을(를) 비웁니다. |
+| `RefreshTexture` | texture을(를) 새로 고칩니다. |
+| `LoadBrushMaskTexture` | brush mask texture을(를) 불러옵니다. |
+| `SetBrushMaskTexture` | brush mask texture을(를) 설정합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/TextAlignment.md
+++ b/API_DOCS/TextAlignment.md
@@ -7,7 +7,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/TextComponent.md
+++ b/API_DOCS/TextComponent.md
@@ -7,12 +7,17 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `TextComponent();`
-- `~TextComponent() = default;`
-- `virtual void Awake() override;`
-- `virtual void Update(float tick) override;`
-- `virtual void OnDestroy() override;`
-- `void SetFont(const file::path& path);`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `TextComponent` | text component 동작을 수행합니다. |
+| `~TextComponent` | text component 동작을 수행합니다. |
+| `Awake` | awake 동작을 수행합니다. |
+| `Update` | update을(를) 갱신합니다. |
+| `OnDestroy` | on destroy 동작을 수행합니다. |
+| `SetFont` | font을(를) 설정합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/TransCondition.md
+++ b/API_DOCS/TransCondition.md
@@ -5,15 +5,22 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `TransCondition() = default;`
-- `bool CheckTrans();`
-- `void SetValue(std::string valueName);`
-- `void SetCondition(std::string _parameterName);`
-- `nlohmann::json Serialize();`
-- `TransCondition Deserialize();`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `TransCondition` | trans condition 동작을 수행합니다. |
+| `CheckTrans` | check trans 동작을 수행합니다. |
+| `SetValue` | value을(를) 설정합니다. |
+| `SetCondition` | condition을(를) 설정합니다. |
+| `Serialize` | serialize 동작을 수행합니다. |
+| `Deserialize` | deserialize 동작을 수행합니다. |
 ## Public Properties
-- `std::string valueName = "None";`
-- `ConditionParameter* valueParameter;`
-- `ConditionParameter CompareParameter;`
-- `ConditionType cType = ConditionType::Equal;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `valueName` | value name 상태를 보관합니다. |
+| `valueParameter` | value parameter 상태를 보관합니다. |
+| `CompareParameter` | compare parameter 상태를 보관합니다. |
+| `cType` | c type 상태를 보관합니다. |

--- a/API_DOCS/Transition.md
+++ b/API_DOCS/Transition.md
@@ -5,7 +5,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/Type.md
+++ b/API_DOCS/Type.md
@@ -5,7 +5,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/UIButton.md
+++ b/API_DOCS/UIButton.md
@@ -7,10 +7,17 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `void Update(float deltaSecond) override;`
-- `void UpdateCollider();`
-- `bool CheckClick(Mathf::Vector2 _mousePos);`
-- `void Click();`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `Update` | update을(를) 갱신합니다. |
+| `UpdateCollider` | collider을(를) 갱신합니다. |
+| `CheckClick` | check click 동작을 수행합니다. |
+| `Click` | click 동작을 수행합니다. |
 ## Public Properties
-- `bool isClick = false;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `isClick` | click 여부를 확인합니다. |

--- a/API_DOCS/UIColliderType.md
+++ b/API_DOCS/UIColliderType.md
@@ -7,7 +7,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/UIComponent.md
+++ b/API_DOCS/UIComponent.md
@@ -7,33 +7,40 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `UIComponent();`
-- `virtual ~UIComponent() = default;`
-- `void SetCanvas(Canvas* canvas);`
-- `void SetNavi(Direction dir, const std::shared_ptr<GameObject>& otherUI);`
-- `void DeserializeNavi();`
-- `GameObject* GetNextNavi(Direction dir);`
-- `bool IsNavigationThis();`
-- `void DeserializeShader();`
-- `void SetCustomPixelShader(std::string_view shaderPath);`
-- `std::optional<float> GetFloat(std::string_view name) const;`
-- `void SetFloat(std::string_view name, float value);`
-- `std::optional<float2> GetFloat2(std::string_view name) const;`
-- `void SetFloat2(std::string_view name, const float2& value);`
-- `std::optional<float3> GetFloat3(std::string_view name) const;`
-- `void SetFloat3(std::string_view name, const float3& value);`
-- `std::optional<float4> GetFloat4(std::string_view name) const;`
-- `void SetFloat4(std::string_view name, const float4& value);`
-- `std::optional<int> GetInt(std::string_view name) const;`
-- `void SetInt(std::string_view name, int value);`
-- `std::optional<int2> GetInt2(std::string_view name) const;`
-- `void SetInt2(std::string_view name, const int2& value);`
-- `std::optional<int3> GetInt3(std::string_view name) const;`
-- `void SetInt3(std::string_view name, const int3& value);`
-- `std::optional<int4> GetInt4(std::string_view name) const;`
-- `void SetInt4(std::string_view name, const int4& value);`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `UIComponent` | uicomponent 동작을 수행합니다. |
+| `~UIComponent` | uicomponent 동작을 수행합니다. |
+| `SetCanvas` | canvas을(를) 설정합니다. |
+| `SetNavi` | navi을(를) 설정합니다. |
+| `DeserializeNavi` | deserialize navi 동작을 수행합니다. |
+| `GetNextNavi` | next navi을(를) 가져옵니다. |
+| `IsNavigationThis` | navigation this 여부를 확인합니다. |
+| `DeserializeShader` | deserialize shader 동작을 수행합니다. |
+| `SetCustomPixelShader` | custom pixel shader을(를) 설정합니다. |
+| `GetFloat` | float을(를) 가져옵니다. |
+| `SetFloat` | float을(를) 설정합니다. |
+| `GetFloat2` | float2을(를) 가져옵니다. |
+| `SetFloat2` | float2을(를) 설정합니다. |
+| `GetFloat3` | float3을(를) 가져옵니다. |
+| `SetFloat3` | float3을(를) 설정합니다. |
+| `GetFloat4` | float4을(를) 가져옵니다. |
+| `SetFloat4` | float4을(를) 설정합니다. |
+| `GetInt` | int을(를) 가져옵니다. |
+| `SetInt` | int을(를) 설정합니다. |
+| `GetInt2` | int2을(를) 가져옵니다. |
+| `SetInt2` | int2을(를) 설정합니다. |
+| `GetInt3` | int3을(를) 가져옵니다. |
+| `SetInt3` | int3을(를) 설정합니다. |
+| `GetInt4` | int4을(를) 가져옵니다. |
+| `SetInt4` | int4을(를) 설정합니다. |
 ## Public Properties
-- `UItype type = UItype::None;`
-- `bool isDeserialized = false;`
-- `bool isNavLocked = false;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `type` | type 상태를 보관합니다. |
+| `isDeserialized` | deserialized 여부를 확인합니다. |
+| `isNavLocked` | nav locked 여부를 확인합니다. |

--- a/API_DOCS/UIEffects.md
+++ b/API_DOCS/UIEffects.md
@@ -5,7 +5,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/UIManager.md
+++ b/API_DOCS/UIManager.md
@@ -7,29 +7,34 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `std::shared_ptr<GameObject> MakeCanvas(std::string_view name = "Canvas");`
-- `void AddCanvas(std::shared_ptr<GameObject> canvas);`
-- `void DeleteCanvas(const std::shared_ptr<GameObject>& canvas);`
-- `void CheckInput();`
-- `GameObject* FindCanvasName(const std::shared_ptr<GameObject>& obj, std::string_view name);`
-- `GameObject* FindCanvasIndex(const std::shared_ptr<GameObject>& obj, int index);`
-- `GameObject* FindCanvasName(std::string_view name);`
-- `GameObject* FindCanvasIndex(int index);`
-- `void Update();`
-- `void SortCanvas();`
-- `void RegisterImageComponent(ImageComponent* image);`
-- `void RegisterTextComponent(TextComponent* text);`
-- `void RegisterSpriteSheetComponent(SpriteSheetComponent* spriteSheet);`
-- `void UnregisterImageComponent(ImageComponent* image);`
-- `void UnregisterTextComponent(TextComponent* text);`
-- `void UnregisterSpriteSheetComponent(SpriteSheetComponent* spriteSheet);`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `MakeCanvas` | make canvas 동작을 수행합니다. |
+| `AddCanvas` | canvas을(를) 추가합니다. |
+| `DeleteCanvas` | delete canvas 동작을 수행합니다. |
+| `CheckInput` | check input 동작을 수행합니다. |
+| `FindCanvasName` | canvas name을(를) 탐색합니다. |
+| `FindCanvasIndex` | canvas index을(를) 탐색합니다. |
+| `Update` | update을(를) 갱신합니다. |
+| `SortCanvas` | sort canvas 동작을 수행합니다. |
+| `RegisterImageComponent` | register image component 동작을 수행합니다. |
+| `RegisterTextComponent` | register text component 동작을 수행합니다. |
+| `RegisterSpriteSheetComponent` | register sprite sheet component 동작을 수행합니다. |
+| `UnregisterImageComponent` | unregister image component 동작을 수행합니다. |
+| `UnregisterTextComponent` | unregister text component 동작을 수행합니다. |
+| `UnregisterSpriteSheetComponent` | unregister sprite sheet component 동작을 수행합니다. |
 ## Public Properties
-- `friend class DLLCore::Singleton<UIManager>;`
-- `Core::Delegate<void, Mathf::Vector2> m_clickEvent;`
-- `std::vector<ImageComponent*>			Images;`
-- `std::vector<TextComponent*>			Texts;`
-- `std::vector<SpriteSheetComponent*>    SpriteSheets;`
-- `std::weak_ptr<GameObject> CurCanvas;`
-- `std::weak_ptr<GameObject> SelectUI;`
-- `bool needSort = false;`
+
+### Public Properties 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `Singleton<UIManager>` | singleton<uimanager> 상태를 보관합니다. |
+| `m_clickEvent` | m click event 상태를 보관합니다. |
+| `Images` | images 상태를 보관합니다. |
+| `Texts` | texts 상태를 보관합니다. |
+| `SpriteSheets` | sprite sheets 상태를 보관합니다. |
+| `CurCanvas` | cur canvas 상태를 보관합니다. |
+| `SelectUI` | select ui 상태를 보관합니다. |
+| `needSort` | need sort 상태를 보관합니다. |

--- a/API_DOCS/UItype.md
+++ b/API_DOCS/UItype.md
@@ -7,7 +7,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/ValueType.md
+++ b/API_DOCS/ValueType.md
@@ -7,7 +7,10 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- (none)
 
+### Public Methods 역할
+표로 요약할 멤버가 없습니다.
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/VolumeComponent.md
+++ b/API_DOCS/VolumeComponent.md
@@ -7,10 +7,15 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `void Awake() override;`
-- `void OnDestroy() override;`
-- `void LoadProfile(FileGuid profileGuid);`
-- `void UpdateProfileEditMode();`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `Awake` | awake 동작을 수행합니다. |
+| `OnDestroy` | on destroy 동작을 수행합니다. |
+| `LoadProfile` | profile을(를) 불러옵니다. |
+| `UpdateProfileEditMode` | profile edit mode을(를) 갱신합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/API_DOCS/WeightedSelectorNode.md
+++ b/API_DOCS/WeightedSelectorNode.md
@@ -7,8 +7,13 @@
 > 자동 생성된 문서입니다. 실제 사용 시 구현 파일을 함께 참고하세요.
 
 ## Public Methods
-- `WeightedSelectorNode() = default;`
-- `~WeightedSelectorNode() override = default;`
 
+### Public Methods 역할
+| 멤버 | 예상 역할 |
+| --- | --- |
+| `WeightedSelectorNode` | weighted selector node 동작을 수행합니다. |
+| `~WeightedSelectorNode` | weighted selector node 동작을 수행합니다. |
 ## Public Properties
-- (none)
+
+### Public Properties 역할
+표로 요약할 멤버가 없습니다.

--- a/scripts/generate_api_summary.py
+++ b/scripts/generate_api_summary.py
@@ -1,0 +1,176 @@
+import re
+from pathlib import Path
+
+API_DIR = Path(__file__).resolve().parents[1] / "API_DOCS"
+
+PREFIX_DESCRIPTIONS = {
+    "get": "{subject}을(를) 가져옵니다.",
+    "set": "{subject}을(를) 설정합니다.",
+    "add": "{subject}을(를) 추가합니다.",
+    "remove": "{subject}을(를) 제거합니다.",
+    "find": "{subject}을(를) 탐색합니다.",
+    "update": "{subject}을(를) 갱신합니다.",
+    "create": "{subject}을(를) 생성합니다.",
+    "destroy": "{subject}을(를) 파괴합니다.",
+    "load": "{subject}을(를) 불러옵니다.",
+    "save": "{subject}을(를) 저장합니다.",
+    "apply": "{subject}을(를) 적용합니다.",
+    "calculate": "{subject}을(를) 계산합니다.",
+    "refresh": "{subject}을(를) 새로 고칩니다.",
+    "clear": "{subject}을(를) 비웁니다.",
+    "enable": "{subject}을(를) 활성화합니다.",
+    "disable": "{subject}을(를) 비활성화합니다.",
+    "is": "{subject} 여부를 확인합니다.",
+}
+
+
+def split_words(identifier: str) -> str:
+    cleaned = re.sub(r"operator[^\w]+", "operator", identifier)
+    cleaned = cleaned.replace("~", "")
+    spaced = re.sub(r"([a-z0-9])([A-Z])", r"\1 \2", cleaned)
+    spaced = spaced.replace("_", " ")
+    return spaced.strip().lower()
+
+
+def describe_member(name: str, kind: str) -> str:
+    lower = name.lower()
+    for prefix, template in PREFIX_DESCRIPTIONS.items():
+        if lower.startswith(prefix):
+            subject = split_words(name[len(prefix):] or name)
+            return template.format(subject=subject).strip()
+    if kind == "Method":
+        return f"{split_words(name)} 동작을 수행합니다."
+    return f"{split_words(name)} 상태를 보관합니다."
+
+
+def extract_name(entry: str, kind: str) -> str:
+    if kind == "Method":
+        match = re.search(r"([~A-Za-z_][\w:]*)\s*(?=\()", entry)
+        if match:
+            return match.group(1).split("::")[-1]
+
+    tokens = re.split(r"[\s=;(),]+", entry.strip())
+    ignored = {"const", "static", "mutable", "volatile", "constexpr", "using"}
+    primitive_types = {
+        "int",
+        "uint",
+        "uint32",
+        "uint64",
+        "int32",
+        "int64",
+        "float",
+        "double",
+        "bool",
+        "char",
+        "short",
+        "long",
+        "size_t",
+    }
+
+    for token in reversed(tokens):
+        if not token or set(token) <= {"`", "-"}:
+            continue
+        if token in ignored:
+            continue
+        if token.lower() in primitive_types:
+            continue
+        if not re.search(r"[A-Za-z_]", token):
+            continue
+        return token.split("::")[-1]
+
+    return "Unknown"
+
+
+def parse_entries(lines, kind: str):
+    bullet_entries = []
+    table_entries = []
+
+    for line in lines:
+        stripped = line.strip()
+
+        if stripped.startswith("-"):
+            content = stripped.lstrip("- ")
+            content = content.split("=", 1)[0]
+            content = content.strip("`")
+            if not content:
+                continue
+            if content.strip().lower().startswith("(none"):
+                continue
+            name = extract_name(content, kind)
+            description = describe_member(name, kind)
+            bullet_entries.append((name, kind, description))
+            continue
+
+        if stripped.startswith("|"):
+            match = re.match(r"\|\s*`([^`]+)`\s*\|", stripped)
+            if match:
+                name = match.group(1)
+                description = describe_member(name, kind)
+                table_entries.append((name, kind, description))
+
+    return bullet_entries or table_entries
+
+
+def build_table(title: str, entries: list[tuple[str, str, str]]) -> str:
+    if not entries:
+        return f"### {title} 역할\n표로 요약할 멤버가 없습니다."
+
+    header = [
+        f"### {title} 역할",
+        "| 멤버 | 예상 역할 |",
+        "| --- | --- |",
+    ]
+    rows = [f"| `{name}` | {desc} |" for name, _, desc in entries]
+    return "\n".join(header + rows)
+
+
+def rebuild_section(content_lines: list[str], header: str) -> list[str]:
+    rebuilt = []
+    i = 0
+    while i < len(content_lines):
+        line = content_lines[i]
+        rebuilt.append(line)
+        if line.strip() == f"## {header}":
+            section_start = i + 1
+            j = section_start
+            while j < len(content_lines) and not content_lines[j].startswith("## "):
+                j += 1
+
+            section_body = content_lines[section_start:j]
+            entries = parse_entries(section_body, "Method" if header == "Public Methods" else "Property")
+
+            deduped = []
+            seen = set()
+            for name, kind, desc in entries:
+                if name in seen:
+                    continue
+                seen.add(name)
+                deduped.append((name, kind, desc))
+
+            table_block = build_table(header, deduped).splitlines()
+            rebuilt.append("")
+            rebuilt.extend(table_block)
+            i = j
+            continue
+        i += 1
+    return rebuilt
+
+
+def apply_section(path: Path) -> None:
+    content = path.read_text(encoding="utf-8")
+    stripped = re.sub(r"## (?:역할|정적 역할) 요약\n(?:.*?)(?=\n## |\Z)", "", content, flags=re.DOTALL)
+    lines = stripped.splitlines()
+
+    for header in ("Public Methods", "Public Properties"):
+        lines = rebuild_section(lines, header)
+
+    path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def main():
+    for path in sorted(API_DIR.glob("*.md")):
+        apply_section(path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- update the API doc generator to strip initializer parts, deduplicate entries, and rebuild Public Methods/Properties sections as tables without keeping old lists
- regenerate all API markdown files so only the section tables remain and default values no longer leak into role names

## Testing
- python scripts/generate_api_summary.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692872092abc832d830e9797a179ec0f)